### PR TITLE
Fix workflow to build Thread Safe version on Windows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -101,7 +101,7 @@ jobs:
                 run: |
                     PHP_VER="${{ inputs.php-version || '8.5' }}"
                     TS_TAG="${{ matrix.ts }}"
-                    echo "artifact_name=php-debugger-php${PHP_VER}-windows-x64-${TS_TAG}" >> $GITHUB_OUTPUT
+                    echo "artifact_name=php-debugger-php${PHP_VER}-${TS_TAG}-windows-x64" >> $GITHUB_OUTPUT
 
             -   name: Find DLL
                 id: find-dll

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -75,8 +75,14 @@ jobs:
                     retention-days: 90
 
     build-windows:
+        strategy:
+            fail-fast: false
+            matrix:
+                ts:
+                    - nts
+                    - ts
         runs-on: windows-2022
-        name: "Windows (x64) — PHP ${{ inputs.php-version || '8.5' }}"
+        name: "Windows (x64) — PHP ${{ inputs.php-version || '8.5' }} — ${{ matrix.ts == 'ts' && 'TS' || 'NTS' }}"
         steps:
             -   uses: actions/checkout@v6
 
@@ -85,7 +91,7 @@ jobs:
                 with:
                     php-version: ${{ inputs.php-version || '8.5' }}
                     arch: x64
-                    ts: nts
+                    ts: ${{ matrix.ts }}
                     args: --enable-debugger
                     run-tests: false
 
@@ -94,7 +100,8 @@ jobs:
                 shell: bash
                 run: |
                     PHP_VER="${{ inputs.php-version || '8.5' }}"
-                    echo "artifact_name=php-debugger-php${PHP_VER}-windows-x64" >> $GITHUB_OUTPUT
+                    TS_TAG="${{ matrix.ts }}"
+                    echo "artifact_name=php-debugger-php${PHP_VER}-windows-x64-${TS_TAG}" >> $GITHUB_OUTPUT
 
             -   name: Find DLL
                 id: find-dll

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -76,8 +76,11 @@ jobs:
                     - '8.3'
                     - '8.4'
                     - '8.5'
+                ts:
+                  - nts
+                  - ts
         runs-on: windows-2022
-        name: "Windows — PHP ${{ matrix.php-version }}"
+        name: "Windows — PHP ${{ matrix.php-version }} — ${{ matrix.ts == 'ts' && 'TS' || 'NTS' }}"
         steps:
             -   uses: actions/checkout@v6
 
@@ -86,7 +89,7 @@ jobs:
                 with:
                     php-version: ${{ matrix.php-version }}
                     arch: x64
-                    ts: nts
+                    ts: ${{ matrix.ts }}
                     args: --enable-debugger
                     run-tests: false
 
@@ -95,7 +98,8 @@ jobs:
                 shell: pwsh
                 run: |
                     $phpVer = "${{ matrix.php-version }}"
-                    $assetName = "php-debugger-php${phpVer}-windows-x64.dll"
+                    $tsTag = "${{ matrix.ts }}"
+                    $assetName = "php-debugger-php${phpVer}-${tsTag}-windows-x64.dll"
                     $dll = Get-ChildItem -Path $env:RUNNER_TEMP -Recurse -Filter 'php_debugger.dll' -ErrorAction SilentlyContinue | Select-Object -First 1
                     if (-not $dll) {
                         $dll = Get-ChildItem -Recurse -Filter 'php_debugger.dll' -ErrorAction SilentlyContinue | Select-Object -First 1


### PR DESCRIPTION
Summary

Adds support for building the Thread Safe version of the PHP extension on Windows in the workflow.

Changes

Added Thread Safe build configuration for Windows
Extended workflow to include Windows Thread Safe builds

Notes

Previously, the Thread Safe version was not built for Windows.