### PR TITLE
Restore CI Benchmark

### DIFF
--- a/.github/benchmark-files/generate_summary.php
+++ b/.github/benchmark-files/generate_summary.php
@@ -5,7 +5,7 @@
  *
  * This script reads benchmark results from the results directory, merges them
  * into a single directory, and generates a markdown summary with performance
- * metrics for different PHP versions, commands, and Xdebug modes.
+ * metrics for different PHP versions, commands, and Php-Debugger modes.
  */
 
 // Create merged directory and copy all result files into it
@@ -67,32 +67,32 @@ $matrixValues = $allMatrixValues;
 // Extract unique values for each dimension
 $commands = [];
 $phpVersions = [];
-$xdebugModes = [];
+$phpDebuggerModes = [];
 
 foreach ($matrixValues as $line) {
-    [$php, $command, $xdebug] = explode(',', $line);
+    [$php, $command, $phpDebugger] = explode(',', $line);
     $phpVersions[$php] = true;
     $commands[$command] = true;
-    $xdebugModes[$xdebug] = true;
+    $phpDebuggerModes[$phpDebugger] = true;
 }
 
 // Sort the arrays
 $commands = array_keys($commands);
 $phpVersions = array_keys($phpVersions);
-$xdebugModes = array_keys($xdebugModes);
+$phpDebuggerModes = array_keys($phpDebuggerModes);
 sort($commands);
 sort($phpVersions);
 
-// Sort xdebug modes according to the defined order, leaving only those which actually exist in the data
-$xdebugModeOrder = ["no", "off", "coverage", "debug", "develop", "gcstats", "profile", "trace"];
-$xdebugModes = array_values(array_filter($xdebugModeOrder, function($mode) use ($xdebugModes) {
-    return in_array($mode, $xdebugModes);
+// Sort Php-Debugger modes according to the defined order, leaving only those which actually exist in the data
+$phpDebuggerModeOrder = ["no", "off", "debug"];
+$phpDebuggerModes = array_values(array_filter($phpDebuggerModeOrder, function($mode) use ($phpDebuggerModes) {
+    return in_array($mode, $phpDebuggerModes);
 }));
 
 // Start building the markdown summary and CSV data
 $output = "# 🕒 Performance Results\n";
 $csvData = [];
-$csvData[] = ['command', 'php', 'xdebug_mode', 'instructions', 'slowdown'];
+$csvData[] = ['command', 'php', 'php_debugger_mode', 'instructions', 'slowdown'];
 
 // Loop through each command
 foreach ($commands as $command) {
@@ -101,11 +101,11 @@ foreach ($commands as $command) {
     // Loop through each PHP version
     foreach ($phpVersions as $php) {
         $output .= "\n### **PHP Version:** `$php`\n\n";
-        $output .= "| Xdebug | Instructions | Slowdown | Δ Instructions |\n";
-        $output .= "|--------|-------------:|---------:|---------------:|\n";
+        $output .= "| Php-Debugger | Instructions | Slowdown | Improvement |\n";
+        $output .= "|--------------|-------------:|---------:|------------:|\n";
 
-        // Get base value (when Xdebug mode is "no")
-        $baseFile = "merged/php-{$php}_cmd-{$command}_xdebug-no.txt";
+        // Get base value (when Php-Debugger mode is "no")
+        $baseFile = "merged/php-{$php}_cmd-{$command}_php_debugger-no.txt";
         if (!file_exists($baseFile)) {
             fwrite(STDERR, "Warning: Base file not found: $baseFile\n");
             continue;
@@ -113,9 +113,9 @@ foreach ($commands as $command) {
 
         $baseValue = (int)trim(file_get_contents($baseFile));
 
-        // Loop through each Xdebug mode
-        foreach ($xdebugModes as $xdebug) {
-            $file = "merged/php-{$php}_cmd-{$command}_xdebug-{$xdebug}.txt";
+        // Loop through each Php-Debugger mode
+        foreach ($phpDebuggerModes as $phpDebugger) {
+            $file = "merged/php-{$php}_cmd-{$command}_php_debugger-{$phpDebugger}.txt";
 
             if (!file_exists($file)) {
                 continue;
@@ -124,7 +124,7 @@ foreach ($commands as $command) {
             $value = (int)trim(file_get_contents($file));
 
             // Calculate slowdown
-            if ($xdebug === 'no') {
+            if ($phpDebugger === 'no') {
                 $slowdown = '0%';
                 $slowdownPercent = 0.0;
             } else {
@@ -137,19 +137,21 @@ foreach ($commands as $command) {
 
             // Calculate performance change compared to previous results
             $performanceChange = '--';
-            $key = $command . '-' . $php . '-' . $xdebug;
+            $key = $command . '-' . $php . '-' . $phpDebugger;
             if (isset($previousResults[$key])) {
-                $previousValue = $previousResults[$key];
-                // Calculate percentage change: (new - old) / old * 100
-                // Positive means slower (more instructions), negative means faster
-                $changePercent = (($value - $previousValue) * 100) / $previousValue;
-                $performanceChange = sprintf('%+.1f%%', $changePercent);
+                $previousSlowdown = $previousResults[$key];
+                $performanceChange = '0%';
+                if ($previousSlowdown !== 0) {
+                    $currentSlowdown = sprintf('%.1f', $slowdownPercent);
+                    $changePercent = (($previousSlowdown - $currentSlowdown) * 100) / $previousSlowdown;
+                    $performanceChange = sprintf('%+.1f%%', $changePercent);
+                }
             }
 
-            $output .= "| $xdebug | $formattedValue | $slowdown | $performanceChange |\n";
+            $output .= "| $phpDebugger | $formattedValue | $slowdown | $performanceChange |\n";
 
             // Add to CSV data (with raw numbers, not formatted)
-            $csvData[] = [$command, $php, $xdebug, $value, sprintf('%.1f', $slowdownPercent)];
+            $csvData[] = [$command, $php, $phpDebugger, $value, sprintf('%.1f', $slowdownPercent)];
         }
     }
 }
@@ -158,15 +160,15 @@ foreach ($commands as $command) {
 $output .= "\n# Performance Results Summary\n";
 $output .= "\nThese tables show aggregated results across all PHP versions:\n";
 
-// Aggregate data across all PHP versions for each command and xdebug mode
+// Aggregate data across all PHP versions for each command and Php-Debugger mode
 foreach ($commands as $command) {
     $output .= "\n## **Command:** `$command`\n\n";
-    $output .= "| Xdebug | Slowdown | Δ Instructions |\n";
-    $output .= "|--------|---------:|---------------:|\n";
+    $output .= "| Php-Debugger | Slowdown | Improvement |\n";
+    $output .= "|--------------|---------:|------------:|\n";
 
-    // Calculate aggregated values for each xdebug mode
+    // Calculate aggregated values for each Php-Debugger mode
     $aggregatedData = [];
-    foreach ($xdebugModes as $xdebug) {
+    foreach ($phpDebuggerModes as $phpDebugger) {
         $totalInstructions = 0;
         $totalBaseInstructions = 0;
         $count = 0;
@@ -174,8 +176,8 @@ foreach ($commands as $command) {
         $performanceChangeCount = 0;
 
         foreach ($phpVersions as $php) {
-            $file = "merged/php-{$php}_cmd-{$command}_xdebug-{$xdebug}.txt";
-            $baseFile = "merged/php-{$php}_cmd-{$command}_xdebug-no.txt";
+            $file = "merged/php-{$php}_cmd-{$command}_php_debugger-{$phpDebugger}.txt";
+            $baseFile = "merged/php-{$php}_cmd-{$command}_php_debugger-no.txt";
 
             if (file_exists($file) && file_exists($baseFile)) {
                 $value = (int)trim(file_get_contents($file));
@@ -185,11 +187,17 @@ foreach ($commands as $command) {
                 $totalBaseInstructions += $baseValue;
                 $count++;
 
+                $slowdownPercent = (($value - $baseValue) * 100) / $baseValue;
+
                 // Calculate performance change if previous data exists
-                $key = $command . '-' . $php . '-' . $xdebug;
+                $key = $command . '-' . $php . '-' . $phpDebugger;
                 if (isset($previousResults[$key])) {
-                    $previousValue = $previousResults[$key];
-                    $changePercent = (($value - $previousValue) * 100) / $previousValue;
+                    $previousSlowdown = $previousResults[$key];
+                    $changePercent = 0;
+                    if ($previousSlowdown !== 0) {
+                        $currentSlowdown = sprintf('%.1f', $slowdownPercent);
+                        $changePercent = (($previousSlowdown - $currentSlowdown) * 100) / $previousSlowdown;
+                    }
                     $totalPerformanceChange += $changePercent;
                     $performanceChangeCount++;
                 }
@@ -198,7 +206,7 @@ foreach ($commands as $command) {
 
         if ($count > 0) {
             // Calculate average slowdown
-            if ($xdebug === 'no') {
+            if ($phpDebugger === 'no') {
                 $avgSlowdown = '0%';
             } else {
                 $avgSlowdownPercent = (($totalInstructions - $totalBaseInstructions) * 100) / $totalBaseInstructions;
@@ -212,7 +220,7 @@ foreach ($commands as $command) {
                 $performanceChange = sprintf('%+.1f%%', $avgPerformanceChange);
             }
 
-            $output .= "| $xdebug | $avgSlowdown | $performanceChange |\n";
+            $output .= "| $phpDebugger | $avgSlowdown | $performanceChange |\n";
         }
     }
 }
@@ -278,13 +286,20 @@ function githubApiRequest(string $url): string|false {
 /**
  * Fetches benchmark results from the latest successful run of the benchmark workflow on the base branch.
  *
- * @return array Array indexed by "command-php-xdebug" with instruction counts, or empty array if not found
+ * @return array Array indexed by "command-php-php_debugger" with instruction counts, or empty array if not found
  */
 function fetchPreviousBenchmarkResults(): array {
     // Determine the base branch for comparison
-    // For pull requests, use GITHUB_BASE_REF
+    // If COMPARISON_BRANCH is set, use it explicitly
+    // Otherwise for pull requests, use GITHUB_BASE_REF
     // For other actions, use GITHUB_REF_NAME (current branch)
-    $baseBranch = getenv('GITHUB_BASE_REF') ?: getenv('GITHUB_REF_NAME');
+    $comparisonBranch = getenv('COMPARISON_BRANCH');
+    if ($comparisonBranch !== false && $comparisonBranch !== '') {
+        $baseBranch = $comparisonBranch;
+    } else {
+        $baseBranch = getenv('GITHUB_BASE_REF') ?: getenv('GITHUB_REF_NAME');
+    }
+
     if (!$baseBranch) {
         fwrite(STDERR, "Warning: Could not determine base branch for comparison\n");
         return [];
@@ -389,9 +404,9 @@ function fetchPreviousBenchmarkResults(): array {
         }
 
         if (count($fields) >= 4) {
-            // Fields: command, php, xdebug_mode, instructions, slowdown
+            // Fields: command, php, php_debugger_mode, instructions, slowdown
             $key = $fields[0] . '-' . $fields[1] . '-' . $fields[2];
-            $previousData[$key] = (int)$fields[3];
+            $previousData[$key] = (int)$fields[4];
         }
     }
 

--- a/.github/benchmark-files/php-debugger-benchmark.ini
+++ b/.github/benchmark-files/php-debugger-benchmark.ini
@@ -1,4 +1,4 @@
-zend_extension=xdebug
-xdebug.start_with_request=no
+zend_extension=php_debugger.so
+php_debugger.start_with_request=no
 ; We need this because some of the functions in bench.php do deep recursion and the default nesting level is not enough
-xdebug.max_nesting_level=2048
+php_debugger.max_nesting_level=2048

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -1,0 +1,203 @@
+name: Benchmark Php-Debugger performance
+
+on:
+    # This workflow runs on three triggers: Weekly on schedule, manually, or when pull requests are labeled
+    schedule:
+        # Every Sunday at 03:00 UTC
+        - cron: '0 3 * * 0'
+    workflow_dispatch: 
+    pull_request:
+        types: [ labeled ]
+
+jobs:
+    run-benchmark:
+        # When triggered when a pull request is labeled we check the name of the label
+        if: |
+            github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' ||
+            (
+                github.event_name == 'pull_request' &&
+                github.event.label.name == 'performance-check'
+            )
+        runs-on: ubuntu-latest
+        strategy:
+            fail-fast: false
+            matrix:
+                command: ["bench", "symfony", "rector"]
+                php: ["8.2", "8.3", "8.4", "8.5"]
+                php_debugger_mode: ["no", "off", "debug"]
+        steps:
+            -   uses: actions/checkout@v6
+
+            -   name: Setup PHP
+                uses: shivammathur/setup-php@v2
+                with:
+                    php-version: "${{ matrix.php }}"
+                    coverage: none
+                    # We need to use a specific version of Composer because we are using a specific version of the
+                    # Symfony Demo which is not compatible with the latest versions of Composer
+                    tools: composer:v2.2.21
+
+            -   name: Disable ASLR
+                # ASLR can cause a lot of noise due to missed sse opportunities for memcpy
+                # and other operations, so we disable it during benchmarking.
+                run: echo 0 | sudo tee /proc/sys/kernel/randomize_va_space
+
+            -   name: Install valgrind
+                run: sudo apt-get update && sudo apt-get install -y valgrind
+                    
+            -   name: Compile
+                run: |
+                    phpize
+                    ./configure --enable-php-debugger
+                    make -j$(nproc)
+                    sudo make install
+
+            -   name: create results and opcache folder
+                run: |
+                    mkdir -p results
+                    mkdir -p /tmp/opcache
+
+            -   name: install Symfony demo
+                if: matrix.command == 'symfony'   
+                # For versions of PHP greater than 8.4 we need to run a different version of the Symfony Demo.
+                # The older versions suffer from the nulllable parameter deprecation and this generated a lot of
+                # deprecations in the code and this skewed the tests results a lot. And we cannot use the newer version
+                # for older versions of PHP as it is not compatible.
+                run: |
+                    if [ "${{ matrix.php }}" \< "8.4" ]; then
+                        version="v2.0.2"
+                    else
+                        version="v2.7.0"
+                    fi
+                    git clone -q --branch "$version" --depth 1 https://github.com/symfony/demo.git ./symfony-demo
+                    cd symfony-demo
+                    composer install 
+                    # We do not want our tests to be skewed by any error, warning, notice or deprecation thrown by the
+                    # code, so we set the error level to 0 on purpose. Unfortunately, Symfony overrides this setup and
+                    # sets their own error reporting level. We fix this by changing all the places where Symfony is
+                    # setting the error reporting level so that it continues to be set to 0
+                    find . -type f -name "*.php" -exec sed -i.bak -E 's/error_reporting\(.*\);/error_reporting(0);/g' {} +
+
+            -   name: install Rector
+                if: matrix.command == 'rector'   
+                run: |
+                    composer require rector/rector:2.1.2 phpstan/phpstan:2.1.33 --dev
+                    cp .github/benchmark-files/rector.php .
+
+            -   name: Copy ini file
+                run: |
+                    sudo cp ./.github/benchmark-files/benchmark.ini /etc/php/${{ matrix.php }}/cli/conf.d
+                    sudo cp ./.github/benchmark-files/benchmark.ini /etc/php/${{ matrix.php }}/cgi/conf.d
+
+            -   name: Copy php_debugger ini file
+                if: matrix.php_debugger_mode != 'no'
+                run: |
+                    sudo cp ./.github/benchmark-files/php-debugger-benchmark.ini /etc/php/${{ matrix.php }}/cli/conf.d
+                    sudo cp ./.github/benchmark-files/php-debugger-benchmark.ini /etc/php/${{ matrix.php }}/cgi/conf.d
+    
+            -   name: Set Php-Debugger mode
+                run: echo "PHP_DEBUGGER_MODE=${{ matrix.php_debugger_mode }}" >> $GITHUB_ENV
+
+            -   name: Confirm PHP setup
+                run: | 
+                    php -v
+                    php -i
+
+            -   name: benchmark bench.php
+                if: matrix.command == 'bench'   
+                run: valgrind --tool=callgrind --dump-instr=yes --callgrind-out-file=callgrind.out -- php ./.github/benchmark-files/bench.php
+
+            -   name: benchmark Symfony
+                if: matrix.command == 'symfony'   
+                run: |
+                    cd symfony-demo
+                    # The Symfony demo is run using php-cgi to simulate a web server. Symfony needs that this env
+                    # variable is set, it would usually be set by the web server, we need to set it manually instead
+                    export SCRIPT_FILENAME="$(realpath public/index.php)"
+                    # Symfony also needs this to be set to a non empty value
+                    export APP_SECRET=APP_SECRET
+                    # We run the web page twice so that the files have already been compiled into the opcache in order
+                    # to remove the compilation time from the equation. This also better reflects the normal situation
+                    # in a web server
+                    php-cgi public/index.php
+                    valgrind --tool=callgrind --dump-instr=yes --callgrind-out-file=callgrind.out -- php-cgi public/index.php
+                    mv callgrind.out ..
+                    cd ..
+
+            -   name: benchmark rector.php
+                if: matrix.command == 'rector' 
+                # Rector needs to be run with the --xdebug flag so that it does not try to disable Php-Debugger and also with
+                # the --debug flag so that it does not try to run several threads in parallel
+                run: valgrind --tool=callgrind --dump-instr=yes --callgrind-out-file=callgrind.out -- php vendor/bin/rector --dry-run --xdebug --debug || true
+
+            -   name: save matrix values
+                run: |
+                    # We read the number of executed instructions from the callgrind.out file and save it in an artifact
+                    # to be processed later
+                    awk '/^summary:/ { print $2 }' callgrind.out > results/php-${{ matrix.php }}_cmd-${{ matrix.command }}_php_debugger-${{ matrix.php_debugger_mode }}.txt
+                    # We also save the matrix variables so that in a later step we can build a list of the executed
+                    # options
+                    echo "${{ matrix.php }},${{ matrix.command }},${{ matrix.php_debugger_mode }}" > results/matrix-values-${{ matrix.php }}-${{ matrix.command }}-${{ matrix.php_debugger_mode }}.txt
+
+            -   name: Upload result and matrix info
+                uses: actions/upload-artifact@v6
+                with:
+                    name: results-${{ matrix.command }}-${{ matrix.php }}-${{ matrix.php_debugger_mode }}
+                    path: results/
+
+    performance:
+        # After running all benchmarks for all commands, PHP versions and Php-Debugger modes, we run a new job that builds a
+        # summary of all execution times
+        needs: run-benchmark
+        runs-on: ubuntu-latest
+        strategy:
+            fail-fast: false
+            matrix:
+                comparison:
+                    - name: "base-branch"
+                      branch: "" # Empty means use default base branch logic
+                    - name: "base"
+                      branch: "base"
+        steps:
+            -   name: Setup PHP
+                uses: shivammathur/setup-php@v2
+                with:
+                    php-version: "8.5"
+                    coverage: none
+
+            -   uses: actions/checkout@v6
+
+            -   name: Download all artifacts
+                uses: actions/download-artifact@v7
+                with:
+                    path: results
+
+            -   name: Generate summary table as markdown
+                env:
+                    GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+                    COMPARISON_BRANCH: ${{ matrix.comparison.branch }}
+                run: php .github/benchmark-files/generate_summary.php
+
+            -   name: print summary
+                # This generated summary file is copied into a special file which GitHub has defined
+                # in this special env variable and it will use it to print a summary for the workflow
+                run: cat summary.md >> $GITHUB_STEP_SUMMARY
+
+            -   name: Upload summary.csv as artifact
+                if: matrix.comparison.name == 'base-branch'
+                uses: actions/upload-artifact@v6
+                with:
+                    name: summary.csv
+                    path: summary.csv
+
+    cleanup:
+        # Clean up intermediary artifacts after both performance jobs complete
+        needs: performance
+        runs-on: ubuntu-latest
+        steps:
+            -   name: delete intermediary artifacts
+                # The intermediate files that we generated are not needed and can be deleted,
+                # helping us keep the summary page clean
+                uses: geekyeggo/delete-artifact@v6
+                with:
+                    name: results-*


### PR DESCRIPTION
The original Xdebug had a performance measuring mechanism that used the count of executed instructions instead of time. This is much more precise and does not depend on random conditions which can skew timings. This PR recovers this mechanism and runs a benchmark. This benchmark is then compared with two branches: the base branch for any pull request and a "base" branch which represents the original Xdebug and we produce two summaries with these two results

In order to run this performance checks we need to add the `performance-check` label to any PR (this will also be run every week and can be run on demand)

You can see a sample of the results here:
https://github.com/pronskiy/php-debugger/actions/runs/23285783251

(the improvement over the base branch for the pull request is empty because this has not yet been run on the "main" branch before)