### PR TITLE
feat: disable JIT debugging by default

### DIFF
--- a/.github/benchmark-files/generate_summary.php
+++ b/.github/benchmark-files/generate_summary.php
@@ -84,7 +84,7 @@ sort($commands);
 sort($phpVersions);
 
 // Sort PHP Debugger modes according to the defined order, leaving only those which actually exist in the data
-$phpDebuggerModeOrder = ["no", "off", "debug"];
+$phpDebuggerModeOrder = ["no", "off", "debug", "debug-jit"];
 $phpDebuggerModes = array_values(array_filter($phpDebuggerModeOrder, function($mode) use ($phpDebuggerModes) {
     return in_array($mode, $phpDebuggerModes);
 }));
@@ -138,6 +138,10 @@ foreach ($commands as $command) {
             // Calculate performance change compared to previous results
             $performanceChange = '--';
             $key = $command . '-' . $php . '-' . $phpDebugger;
+            $comparisonBranch = getenv('COMPARISON_BRANCH');
+            if ($phpDebugger == 'debug-jit' && $comparisonBranch !== false && $comparisonBranch !== '') {
+                $key = $command . '-' . $php . '-debug';
+            }
             if (isset($previousResults[$key])) {
                 $previousOverhead = $previousResults[$key];
                 $performanceChange = '0%';
@@ -191,6 +195,10 @@ foreach ($commands as $command) {
 
                 // Calculate performance change if previous data exists
                 $key = $command . '-' . $php . '-' . $phpDebugger;
+                $comparisonBranch = getenv('COMPARISON_BRANCH');
+                if ($phpDebugger == 'debug-jit' && $comparisonBranch !== false && $comparisonBranch !== '') {
+                    $key = $command . '-' . $php . '-debug';
+                }
                 if (isset($previousResults[$key])) {
                     $previousOverhead = $previousResults[$key];
                     $changePercent = 0;

--- a/.github/benchmark-files/generate_summary.php
+++ b/.github/benchmark-files/generate_summary.php
@@ -84,7 +84,7 @@ sort($commands);
 sort($phpVersions);
 
 // Sort PHP Debugger modes according to the defined order, leaving only those which actually exist in the data
-$phpDebuggerModeOrder = ["no", "off", "debug", "debug-jit"];
+$phpDebuggerModeOrder = ["no", "off", "debug", "debug-on-demand"];
 $phpDebuggerModes = array_values(array_filter($phpDebuggerModeOrder, function($mode) use ($phpDebuggerModes) {
     return in_array($mode, $phpDebuggerModes);
 }));
@@ -139,7 +139,7 @@ foreach ($commands as $command) {
             $performanceChange = '--';
             $key = $command . '-' . $php . '-' . $phpDebugger;
             $comparisonBranch = getenv('COMPARISON_BRANCH');
-            if ($phpDebugger == 'debug-jit' && $comparisonBranch !== false && $comparisonBranch !== '') {
+            if ($phpDebugger == 'debug-on-demand' && $comparisonBranch !== false && $comparisonBranch !== '') {
                 $key = $command . '-' . $php . '-debug';
             }
             if (isset($previousResults[$key])) {
@@ -196,7 +196,7 @@ foreach ($commands as $command) {
                 // Calculate performance change if previous data exists
                 $key = $command . '-' . $php . '-' . $phpDebugger;
                 $comparisonBranch = getenv('COMPARISON_BRANCH');
-                if ($phpDebugger == 'debug-jit' && $comparisonBranch !== false && $comparisonBranch !== '') {
+                if ($phpDebugger == 'debug-on-demand' && $comparisonBranch !== false && $comparisonBranch !== '') {
                     $key = $command . '-' . $php . '-debug';
                 }
                 if (isset($previousResults[$key])) {

--- a/.github/benchmark-files/php-debugger-jit-benchmark.ini
+++ b/.github/benchmark-files/php-debugger-jit-benchmark.ini
@@ -2,3 +2,4 @@ zend_extension=php_debugger.so
 xdebug.start_with_request=no
 ; We need this because some of the functions in bench.php do deep recursion and the default nesting level is not enough
 xdebug.max_nesting_level=2048
+xdebug.jit_debugging_enabled=1

--- a/.github/benchmark-files/php-debugger-on-demand-benchmark.ini
+++ b/.github/benchmark-files/php-debugger-on-demand-benchmark.ini
@@ -2,4 +2,4 @@ zend_extension=php_debugger.so
 xdebug.start_with_request=no
 ; We need this because some of the functions in bench.php do deep recursion and the default nesting level is not enough
 xdebug.max_nesting_level=2048
-xdebug.jit_debugging_enabled=1
+xdebug.on_demand_debugging_enabled=1

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -24,7 +24,7 @@ jobs:
             matrix:
                 command: ["bench", "symfony", "rector"]
                 php: ["8.2", "8.3", "8.4", "8.5"]
-                php_debugger_mode: ["no", "off", "debug", "debug-jit"]
+                php_debugger_mode: ["no", "off", "debug", "debug-on-demand"]
         steps:
             -   uses: actions/checkout@v6
 
@@ -90,23 +90,23 @@ jobs:
                     sudo cp ./.github/benchmark-files/benchmark.ini /etc/php/${{ matrix.php }}/cgi/conf.d
 
             -   name: Copy php_debugger ini file
-                if: matrix.php_debugger_mode != 'no' && matrix.php_debugger_mode != 'debug-jit'
+                if: matrix.php_debugger_mode != 'no' && matrix.php_debugger_mode != 'debug-on-demand'
                 run: |
                     sudo cp ./.github/benchmark-files/php-debugger-benchmark.ini /etc/php/${{ matrix.php }}/cli/conf.d
                     sudo cp ./.github/benchmark-files/php-debugger-benchmark.ini /etc/php/${{ matrix.php }}/cgi/conf.d
 
-            -   name: Copy jit php_debugger ini file
-                if: matrix.php_debugger_mode == 'debug-jit'
+            -   name: Copy on-demand php_debugger ini file
+                if: matrix.php_debugger_mode == 'debug-on-demand'
                 run: |
-                    sudo cp ./.github/benchmark-files/php-debugger-jit-benchmark.ini /etc/php/${{ matrix.php }}/cli/conf.d
-                    sudo cp ./.github/benchmark-files/php-debugger-jit-benchmark.ini /etc/php/${{ matrix.php }}/cgi/conf.d
+                    sudo cp ./.github/benchmark-files/php-debugger-on-demand-benchmark.ini /etc/php/${{ matrix.php }}/cli/conf.d
+                    sudo cp ./.github/benchmark-files/php-debugger-on-demand-benchmark.ini /etc/php/${{ matrix.php }}/cgi/conf.d
 
             -   name: Set PHP Debugger mode
-                if: matrix.php_debugger_mode != 'debug-jit'
+                if: matrix.php_debugger_mode != 'debug-on-demand'
                 run: echo "PHP_DEBUGGER_MODE=${{ matrix.php_debugger_mode }}" >> $GITHUB_ENV
 
-            -   name: Set PHP JIT Debugger mode
-                if: matrix.php_debugger_mode == 'debug-jit'
+            -   name: Set PHP on-demand Debugger mode
+                if: matrix.php_debugger_mode == 'debug-on-demand'
                 run: echo "PHP_DEBUGGER_MODE=debug" >> $GITHUB_ENV
 
             -   name: Confirm PHP setup

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -24,7 +24,7 @@ jobs:
             matrix:
                 command: ["bench", "symfony", "rector"]
                 php: ["8.2", "8.3", "8.4", "8.5"]
-                php_debugger_mode: ["no", "off", "debug"]
+                php_debugger_mode: ["no", "off", "debug", "debug-jit"]
         steps:
             -   uses: actions/checkout@v6
 
@@ -90,13 +90,24 @@ jobs:
                     sudo cp ./.github/benchmark-files/benchmark.ini /etc/php/${{ matrix.php }}/cgi/conf.d
 
             -   name: Copy php_debugger ini file
-                if: matrix.php_debugger_mode != 'no'
+                if: matrix.php_debugger_mode != 'no' && matrix.php_debugger_mode != 'debug-jit'
                 run: |
                     sudo cp ./.github/benchmark-files/php-debugger-benchmark.ini /etc/php/${{ matrix.php }}/cli/conf.d
                     sudo cp ./.github/benchmark-files/php-debugger-benchmark.ini /etc/php/${{ matrix.php }}/cgi/conf.d
-    
+
+            -   name: Copy jit php_debugger ini file
+                if: matrix.php_debugger_mode == 'debug-jit'
+                run: |
+                    sudo cp ./.github/benchmark-files/php-debugger-jit-benchmark.ini /etc/php/${{ matrix.php }}/cli/conf.d
+                    sudo cp ./.github/benchmark-files/php-debugger-jit-benchmark.ini /etc/php/${{ matrix.php }}/cgi/conf.d
+
             -   name: Set PHP Debugger mode
+                if: matrix.php_debugger_mode != 'debug-jit'
                 run: echo "PHP_DEBUGGER_MODE=${{ matrix.php_debugger_mode }}" >> $GITHUB_ENV
+
+            -   name: Set PHP JIT Debugger mode
+                if: matrix.php_debugger_mode == 'debug-jit'
+                run: echo "PHP_DEBUGGER_MODE=debug" >> $GITHUB_ENV
 
             -   name: Confirm PHP setup
                 run: | 

--- a/.gitignore
+++ b/.gitignore
@@ -83,6 +83,7 @@ phpt.*
 !run-xdebug-tests.php
 !make-release.php
 !bench.php
+!test-ini.php
 !rector.php
 !generate_summary.php
 !tests/debugger/dbgp/dbgpclient.php

--- a/README.md
+++ b/README.md
@@ -46,6 +46,25 @@ We measured three different scenarios which we believe represent a good mix of t
 | Xdebug        | **+35.3%** |
 | PHP Debugger  |  **+1.3%** |
 
+### JIT Debugging
+
+To improve the performance of code running with the PHP Debugger enabled, several features required for just-in-time
+(JIT) debugging are disabled if the debugger does not connect to a client at startup.
+
+JIT debugging allows the debugger to connect later during execution—for example, via `xdebug_connect_to_client()`,
+`xdebug_break()`, or when an error or exception occurs.
+
+We consider JIT debugging to be a relatively uncommon use case, and we want to avoid degrading performance for
+the majority of users. However, since some users rely on this functionality, we provide an INI setting to enable
+it when needed.
+
+INI setting: `php_debugger.jit_debugging_enabled` (default: false)
+
+When this setting is enabled, JIT debugging features remain active even if no client is connected at startup. 
+Note that this has a significant performance impact: instead of achieving up to a 97% performance improvement, the average improvement drops to around 60%.
+
+For this reason, we recommend enabling this setting only if you specifically require JIT debugging.
+
 ## Installation
 
 ### Manual download

--- a/README.md
+++ b/README.md
@@ -46,24 +46,24 @@ We measured three different scenarios which we believe represent a good mix of t
 | Xdebug        | **+35.3%** |
 | PHP Debugger  |  **+1.3%** |
 
-### JIT Debugging
+### On-Demand Debugging
 
-To improve the performance of code running with the PHP Debugger enabled, several features required for just-in-time
-(JIT) debugging are disabled if the debugger does not connect to a client at startup.
+To improve the performance of code running with the PHP Debugger enabled, several features required for on-demand
+debugging are disabled if the debugger does not connect to a client at startup.
 
-JIT debugging allows the debugger to connect later during execution—for example, via `xdebug_connect_to_client()`,
+On-demand debugging allows the debugger to connect later during execution—for example, via `xdebug_connect_to_client()`,
 `xdebug_break()`, or when an error or exception occurs.
 
-We consider JIT debugging to be a relatively uncommon use case, and we want to avoid degrading performance for
+We consider on-demand debugging to be a relatively uncommon use case, and we want to avoid degrading performance for
 the majority of users. However, since some users rely on this functionality, we provide an INI setting to enable
 it when needed.
 
-INI setting: `php_debugger.jit_debugging_enabled` (default: false)
+INI setting: `php_debugger.on_demand_debugging_enabled` (default: false)
 
-When this setting is enabled, JIT debugging features remain active even if no client is connected at startup. 
+When this setting is enabled, on-demand debugging features remain active even if no client is connected at startup. 
 Note that this has a significant performance impact: instead of achieving up to a 97% performance improvement, the average improvement drops to around 60%.
 
-For this reason, we recommend enabling this setting only if you specifically require JIT debugging.
+For this reason, we recommend enabling this setting only if you specifically require on-demand debugging.
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -123,17 +123,18 @@ Works as-is. No changes needed.
 
 PHP Debugger maintains compatibility with Xdebug's debug mode:
 
-| Feature                            | PHP Debugger | Xdebug  |
-|------------------------------------|--------------|---------|
-| `extension_loaded("xdebug")`       | ✅ true       | ✅ true  |
-| `extension_loaded("php_debugger")` | ✅ true       | ❌ false |
-| `xdebug.*` INI settings            | ✅ works      | ✅ works |
-| `xdebug_break()`                   | ✅ works      | ✅ works |
-| `XDEBUG_SESSION` trigger           | ✅ works      | ✅ works |
-| Step debugging (DBGp)              | ✅            | ✅       |
-| Code coverage                      | ❌ use pcov   | ✅       |
-| Profiling                          | ❌ removed    | ✅       |
-| Tracing                            | ❌ removed    | ✅       |
+| Feature                            | PHP Debugger                                                                 | Xdebug |
+|------------------------------------|------------------------------------------------------------------------------|--------|
+| `extension_loaded("xdebug")`       | ✅ true                                                                       | ✅ true |
+| `extension_loaded("php_debugger")` | ✅ true                                                                       | ❌ false |
+| `xdebug.*` INI settings            | ✅ works                                                                      | ✅ works |
+| `xdebug_break()`                   | ✅ works                                                                      | ✅ works |
+| `XDEBUG_SESSION` trigger           | ✅ works                                                                      | ✅ works |
+| Step debugging (DBGp)              | ✅                                                                            | ✅      |
+| On-demand debugging                | ✅ works if `on_demand_debugging_enabled`<br/>is set, does not work otherwise | ✅      |
+| Code coverage                      | ❌ use pcov                                                                   | ✅      |
+| Profiling                          | ❌ removed                                                                    | ✅      |
+| Tracing                            | ❌ removed                                                                    | ✅      |
 
 ### New names (optional)
 

--- a/src/base/base.c
+++ b/src/base/base.c
@@ -715,8 +715,10 @@ static void xdebug_execute_user_code_begin(zend_execute_data *execute_data)
 
 		/* After first-call init, deactivate observer if no debugger connected */
 		if (!xdebug_is_debug_connection_active()) {
-			XG_BASE(observer_active) = 0;
-			return;
+			if (!XINI_DBG(jit_debugging_enabled)) {
+				XG_BASE(observer_active) = 0;
+				return;
+			}
 		}
 	}
 
@@ -1206,16 +1208,8 @@ void xdebug_base_post_startup()
 
 void xdebug_base_rinit()
 {
-	/* Hack: We check for a soap header here, if that's existing, we don't use
-	 * Xdebug's error handler to keep soap fault from fucking up. */
-	if (
-		(XDEBUG_MODE_IS(XDEBUG_MODE_STEP_DEBUG))
-		&&
-		(zend_hash_str_find(Z_ARR(PG(http_globals)[TRACK_VARS_SERVER]), "HTTP_SOAPACTION", sizeof("HTTP_SOAPACTION") - 1) == NULL)
-	) {
-		xdebug_base_use_xdebug_error_cb();
-		xdebug_base_use_xdebug_throw_exception_hook();
-	}
+	XG_BASE(statement_handler_enabled) = true;
+	XG_BASE(observer_active) = true;
 
 	{
 		zend_string *fiber_key = create_key_for_fiber(EG(main_fiber_context));
@@ -1230,12 +1224,6 @@ void xdebug_base_rinit()
 	XG_BASE(function_count) = -1;
 	XG_BASE(last_eval_statement) = NULL;
 	XG_BASE(last_exception_trace) = NULL;
-
-	/* Enable statement handler only when needed */
-	XG_BASE(statement_handler_enabled) = false;
-	if (XDEBUG_MODE_IS(XDEBUG_MODE_STEP_DEBUG)) {
-		XG_BASE(statement_handler_enabled) = true;
-	}
 
 	/* Initialize start time */
 	XG_BASE(start_nanotime) = xdebug_get_nanotime();
@@ -1270,9 +1258,6 @@ void xdebug_base_rinit()
 	/* Signal that we're in a request now */
 	XG_BASE(in_execution) = 1;
 
-	/* Observer starts active to allow first-call debug init check */
-	XG_BASE(observer_active) = XDEBUG_MODE_IS(XDEBUG_MODE_STEP_DEBUG);
-
 	/* filters */
 	XG_BASE(filter_type_stack)         = XDEBUG_FILTER_NONE;
 	XG_BASE(filters_stack)             = xdebug_llist_alloc(xdebug_llist_string_dtor);
@@ -1280,6 +1265,23 @@ void xdebug_base_rinit()
 	/* Warn about Private Temp Directory */
 	if (XG_BASE(private_tmp)) {
 		xdebug_log_ex(XLOG_CHAN_CONFIG, XLOG_INFO, "PRIVTMP", "Systemd Private Temp Directory is enabled (%s)", XG_BASE(private_tmp));
+	}
+}
+
+void xdebug_base_rinit_if_enabled()
+{
+	CG(compiler_options) = CG(compiler_options) | ZEND_COMPILE_EXTENDED_STMT;
+	xdebug_disable_opcache_optimizer();
+
+	/* Hack: We check for a soap header here, if that's existing, we don't use
+	 * Xdebug's error handler to keep soap fault from fucking up. */
+	if (
+		(XDEBUG_MODE_IS(XDEBUG_MODE_STEP_DEBUG))
+		&&
+		(zend_hash_str_find(Z_ARR(PG(http_globals)[TRACK_VARS_SERVER]), "HTTP_SOAPACTION", sizeof("HTTP_SOAPACTION") - 1) == NULL)
+	) {
+		xdebug_base_use_xdebug_error_cb();
+		xdebug_base_use_xdebug_throw_exception_hook();
 	}
 }
 

--- a/src/base/base.c
+++ b/src/base/base.c
@@ -715,7 +715,7 @@ static void xdebug_execute_user_code_begin(zend_execute_data *execute_data)
 
 		/* After first-call init, deactivate observer if no debugger connected */
 		if (!xdebug_is_debug_connection_active()) {
-			if (!XINI_DBG(jit_debugging_enabled)) {
+			if (!XINI_DBG(on_demand_debugging_enabled)) {
 				XG_BASE(observer_active) = 0;
 				return;
 			}

--- a/src/base/base.h
+++ b/src/base/base.h
@@ -23,6 +23,7 @@ void xdebug_base_mshutdown();
 void xdebug_base_post_startup();
 
 void xdebug_base_rinit();
+void xdebug_base_rinit_if_enabled();
 void xdebug_base_post_deactivate();
 void xdebug_base_rshutdown();
 

--- a/src/base/base_globals.h
+++ b/src/base/base_globals.h
@@ -56,6 +56,7 @@ typedef struct _xdebug_base_globals_t {
 	zend_string  *last_eval_statement;
 	char         *last_exception_trace;
 	zend_bool     statement_handler_enabled;
+	zend_bool	  early_connection;
 
 	/* in-execution checking */
 	zend_bool  in_execution;

--- a/src/base/ctrl_socket.c
+++ b/src/base/ctrl_socket.c
@@ -235,6 +235,8 @@ CTRL_FUNC(pause)
 		xdebug_xml_add_text(action, xdstrdup("IDE Connection Signalled"));
 
 		XG_DBG(context).do_connect_to_client = 1;
+
+        XG_BASE(statement_handler_enabled) = true;
 	} else {
 		action = xdebug_xml_node_init("action");
 		xdebug_xml_add_text(action, xdstrdup("Breakpoint Signalled"));

--- a/src/debugger/com.c
+++ b/src/debugger/com.c
@@ -615,7 +615,7 @@ static void xdebug_init_debugger()
 
 	/* If socket was already established by early connect at RINIT,
 	 * skip straight to protocol initialization */
-	if (XG_DBG(context).socket >= 0) {
+	if (XG_BASE(early_connection)) {
 		xdebug_str_add_fmt(connection_attempts, "%s:%ld (through xdebug.client_host/xdebug.client_port)", XINI_DBG(client_host), XINI_DBG(client_port));
 	} else {
 		if (strcmp(XINI_DBG(cloud_id), "") != 0) {
@@ -653,6 +653,8 @@ static void xdebug_init_debugger()
 	} else if (XG_DBG(context).socket == -3) {
 		xdebug_log_ex(XLOG_CHAN_DEBUG, XLOG_ERR, "NOPERM", "No permission connecting to debugging client (%s). This could be SELinux related.", connection_attempts->d);
 	}
+
+	XG_BASE(statement_handler_enabled) = XG_DBG(remote_connection_enabled);
 
 	xdebug_str_free(connection_attempts);
 }

--- a/src/debugger/debugger.c
+++ b/src/debugger/debugger.c
@@ -878,8 +878,6 @@ void xdebug_debugger_rinit(void)
 {
 	char *idekey;
 
-	xdebug_disable_opcache_optimizer();
-
 	/* Get the ide key for this session */
 	XG_DBG(ide_key) = NULL;
 	idekey = xdebug_debugger_get_ide_key();
@@ -1223,6 +1221,10 @@ PHP_FUNCTION(xdebug_break)
 {
 	RETURN_FALSE_IF_MODE_IS_NOT(XDEBUG_MODE_STEP_DEBUG);
 
+	if (!xdebug_is_debug_connection_active() && !XINI_DBG(jit_debugging_enabled)) {
+		RETURN_FALSE;
+	}
+
 	xdebug_debug_init_if_requested_on_xdebug_break();
 
 	if (!xdebug_is_debug_connection_active()) {
@@ -1239,7 +1241,13 @@ PHP_FUNCTION(xdebug_connect_to_client)
 {
 	RETURN_FALSE_IF_MODE_IS_NOT(XDEBUG_MODE_STEP_DEBUG);
 
+	if (!XINI_DBG(jit_debugging_enabled)) {
+		RETURN_FALSE;
+	}
+
 	XG_DBG(context).do_connect_to_client = 1;
+
+    XG_BASE(statement_handler_enabled) = true;
 
 	RETURN_TRUE;
 }

--- a/src/debugger/debugger.c
+++ b/src/debugger/debugger.c
@@ -1222,6 +1222,12 @@ PHP_FUNCTION(xdebug_break)
 	RETURN_FALSE_IF_MODE_IS_NOT(XDEBUG_MODE_STEP_DEBUG);
 
 	if (!xdebug_is_debug_connection_active() && !XINI_DBG(jit_debugging_enabled)) {
+		xdebug_log_ex(XLOG_CHAN_DEBUG, XLOG_INFO, "JIT-OFF",
+				"xdebug_break() ignored: no active debug connection and "
+				"xdebug.jit_debugging_enabled is not enabled");
+		php_error(E_NOTICE,
+				"xdebug_break() ignored: no active debug session and JIT debugging is disabled. "
+				"Set xdebug.jit_debugging_enabled=1 to enable mid-request debugging");
 		RETURN_FALSE;
 	}
 
@@ -1242,6 +1248,11 @@ PHP_FUNCTION(xdebug_connect_to_client)
 	RETURN_FALSE_IF_MODE_IS_NOT(XDEBUG_MODE_STEP_DEBUG);
 
 	if (!XINI_DBG(jit_debugging_enabled)) {
+		xdebug_log_ex(XLOG_CHAN_DEBUG, XLOG_INFO, "JIT-OFF",
+				"xdebug_connect_to_client() ignored: xdebug.jit_debugging_enabled is not enabled");
+		php_error(E_NOTICE,
+				"xdebug_connect_to_client() ignored: JIT debugging is disabled. "
+				"Set xdebug.jit_debugging_enabled=1 to enable mid-request debugging");
 		RETURN_FALSE;
 	}
 

--- a/src/debugger/debugger.c
+++ b/src/debugger/debugger.c
@@ -1221,13 +1221,13 @@ PHP_FUNCTION(xdebug_break)
 {
 	RETURN_FALSE_IF_MODE_IS_NOT(XDEBUG_MODE_STEP_DEBUG);
 
-	if (!xdebug_is_debug_connection_active() && !XINI_DBG(jit_debugging_enabled)) {
+	if (!xdebug_is_debug_connection_active() && !XINI_DBG(on_demand_debugging_enabled)) {
 		xdebug_log_ex(XLOG_CHAN_DEBUG, XLOG_INFO, "JIT-OFF",
 				"xdebug_break() ignored: no active debug connection and "
-				"xdebug.jit_debugging_enabled is not enabled");
+				"xdebug.on_demand_debugging_enabled is not enabled");
 		php_error(E_NOTICE,
-				"xdebug_break() ignored: no active debug session and JIT debugging is disabled. "
-				"Set xdebug.jit_debugging_enabled=1 to enable mid-request debugging");
+				"xdebug_break() ignored: no active debug session and on-demand debugging is disabled. "
+				"Set xdebug.on_demand_debugging_enabled=1 to enable mid-request debugging");
 		RETURN_FALSE;
 	}
 
@@ -1247,12 +1247,12 @@ PHP_FUNCTION(xdebug_connect_to_client)
 {
 	RETURN_FALSE_IF_MODE_IS_NOT(XDEBUG_MODE_STEP_DEBUG);
 
-	if (!XINI_DBG(jit_debugging_enabled)) {
-		xdebug_log_ex(XLOG_CHAN_DEBUG, XLOG_INFO, "JIT-OFF",
-				"xdebug_connect_to_client() ignored: xdebug.jit_debugging_enabled is not enabled");
+	if (!XINI_DBG(on_demand_debugging_enabled)) {
+		xdebug_log_ex(XLOG_CHAN_DEBUG, XLOG_INFO, "ON-DEMAND-OFF",
+				"xdebug_connect_to_client() ignored: xdebug.on_demand_debugging_enabled is not enabled");
 		php_error(E_NOTICE,
-				"xdebug_connect_to_client() ignored: JIT debugging is disabled. "
-				"Set xdebug.jit_debugging_enabled=1 to enable mid-request debugging");
+				"xdebug_connect_to_client() ignored: On-demand debugging is disabled. "
+				"Set xdebug.on_demand_debugging_enabled=1 to enable mid-request debugging");
 		RETURN_FALSE;
 	}
 

--- a/src/debugger/debugger.h
+++ b/src/debugger/debugger.h
@@ -59,7 +59,7 @@ typedef struct _xdebug_debugger_settings_t {
 
 	char         *ide_key_setting; /* Set through php.ini and friends */
 
-	zend_bool     jit_debugging_enabled; /* Enable JIT debugging */
+	zend_bool     on_demand_debugging_enabled; /* Enable on-demand debugging */
 } xdebug_debugger_settings_t;
 
 PHP_INI_MH(OnUpdateDebugMode);

--- a/src/debugger/debugger.h
+++ b/src/debugger/debugger.h
@@ -58,6 +58,8 @@ typedef struct _xdebug_debugger_settings_t {
 	zend_long     connect_timeout_ms; /* Timeout in MS for remote connections */
 
 	char         *ide_key_setting; /* Set through php.ini and friends */
+
+	zend_bool     jit_debugging_enabled; /* Enable JIT debugging */
 } xdebug_debugger_settings_t;
 
 PHP_INI_MH(OnUpdateDebugMode);

--- a/tests/debugger/bug00622.phpt
+++ b/tests/debugger/bug00622.phpt
@@ -26,7 +26,7 @@ $commands = array(
 );
 
 $settings = [
-	'xdebug.jit_debugging_enabled' => 1
+	'xdebug.on_demand_debugging_enabled' => 1
 ];
 
 dbgpRunFile( $filename, $commands, $settings );

--- a/tests/debugger/bug00622.phpt
+++ b/tests/debugger/bug00622.phpt
@@ -25,7 +25,11 @@ $commands = array(
 	'detach'
 );
 
-dbgpRunFile( $filename, $commands );
+$settings = [
+	'xdebug.jit_debugging_enabled' => 1
+];
+
+dbgpRunFile( $filename, $commands, $settings );
 ?>
 --EXPECTF--
 <?xml version="1.0" encoding="iso-8859-1"?>

--- a/tests/debugger/bug00932.phpt
+++ b/tests/debugger/bug00932.phpt
@@ -4,10 +4,9 @@ Test for bug #932: Show an error if Xdebug can't open the remote debug log
 <?php
 require __DIR__ . '/../utils.inc';
 check_reqs('dbgp; !win');
-if (is_stripped_debugger()) die('skip Needs develop mode');
 ?>
 --INI--
-xdebug.mode=develop
+xdebug.mode=debug
 xdebug.log=/doesnotexist/bug932.log
 --FILE--
 <?php

--- a/tests/debugger/bug00964-001.phpt
+++ b/tests/debugger/bug00964-001.phpt
@@ -1,7 +1,5 @@
 --TEST--
 Test for bug #964: IP retrival from X-Forwarded-For complies with RFC 7239 (without comma)
---XFAIL--
-PHP 8.6 CGI changes affect how X-Forwarded-For header IP extraction works. The test expects the debugger to write the client IP to a temp file, but the file is never created.
 --SKIPIF--
 <?php
 require __DIR__ . '/../utils.inc';

--- a/tests/debugger/bug00964-002.phpt
+++ b/tests/debugger/bug00964-002.phpt
@@ -1,7 +1,5 @@
 --TEST--
 Test for bug #964: IP retrival from X-Forwarded-For complies with RFC 7239 (with comma)
---XFAIL--
-PHP 8.6 CGI changes affect how X-Forwarded-For header IP extraction works. The test expects the debugger to write the client IP to a temp file, but the file is never created.
 --SKIPIF--
 <?php
 require __DIR__ . '/../utils.inc';

--- a/tests/debugger/bug01101.phpt
+++ b/tests/debugger/bug01101.phpt
@@ -19,7 +19,7 @@ $commands = array(
 
 dbgpRunFile( $filename, $commands, [
 	'xdebug.start_with_request' => 'trigger',
-	'xdebug.jit_debugging_enabled' => 1
+	'xdebug.on_demand_debugging_enabled' => 1
 ]);
 ?>
 --EXPECT--

--- a/tests/debugger/bug01101.phpt
+++ b/tests/debugger/bug01101.phpt
@@ -1,7 +1,5 @@
 --TEST--
 Test for bug #1101: Debugger is not triggered on xdebug_break() in jit mode.
---XFAIL--
-Phase 2 RINIT observer gating only sets ZEND_COMPILE_EXTENDED_STMT when a debug client connects at RINIT. In trigger/jit mode without a trigger, EXT_STMT opcodes are not emitted, so xdebug_break() cannot do line-level stepping on already-compiled code.
 --SKIPIF--
 <?php
 require __DIR__ . '/../utils.inc';
@@ -19,7 +17,10 @@ $commands = array(
 	'detach',
 );
 
-dbgpRunFile( $filename, $commands, array( 'xdebug.start_with_request' => 'trigger' ) );
+dbgpRunFile( $filename, $commands, [
+	'xdebug.start_with_request' => 'trigger',
+	'xdebug.jit_debugging_enabled' => 1
+]);
 ?>
 --EXPECT--
 <?xml version="1.0" encoding="iso-8859-1"?>

--- a/tests/debugger/bug01915.phpt
+++ b/tests/debugger/bug01915.phpt
@@ -3,7 +3,6 @@ Test for bug #1915: Debugger should only start with XDEBUG_SESSION and not XDEBU
 --SKIPIF--
 <?php
 require __DIR__ . "/../utils.inc";
-if (is_stripped_debugger()) die("skip Needs profile mode");
 ?>
 --ENV--
 XDEBUG_PROFILE=1
@@ -14,7 +13,7 @@ require 'dbgp/dbgpclient.php';
 dbgpRunFile(
 	dirname(__FILE__) . '/empty-echo.inc',
 	['step_into', 'step_into', 'property_get -n $e', 'detach'],
-	['xdebug.mode' => 'debug,profile', 'xdebug.start_with_request' => 'trigger'],
+	['xdebug.mode' => 'debug', 'xdebug.start_with_request' => 'trigger'],
 	['timeout' => 1]
 );
 ?>

--- a/tests/debugger/bug01931-001.phpt
+++ b/tests/debugger/bug01931-001.phpt
@@ -23,7 +23,7 @@ $commands = array(
 $settings = [
 	'xdebug.mode' => 'debug',
 	'xdebug.start_with_request' => 'trigger',
-	'xdebug.jit_debugging_enabled' => 1
+	'xdebug.on_demand_debugging_enabled' => 1
 ];
 
 dbgpRunFile( $filename, $commands, $settings );

--- a/tests/debugger/bug01931-001.phpt
+++ b/tests/debugger/bug01931-001.phpt
@@ -1,7 +1,5 @@
 --TEST--
 Test for bug #1931: No local variables with trigger and xdebug_break() [1]
---XFAIL--
-Phase 2 RINIT observer gating sets observer_active=0 when no debug client connects at RINIT. Without observer callbacks, the stack vector is empty, so xdebug_break()/connect_to_client() cannot report stack frames. Trade-off: 0% overhead when no client vs working mid-request activation.
 --SKIPIF--
 <?php
 require __DIR__ . '/../utils.inc';
@@ -25,6 +23,7 @@ $commands = array(
 $settings = [
 	'xdebug.mode' => 'debug',
 	'xdebug.start_with_request' => 'trigger',
+	'xdebug.jit_debugging_enabled' => 1
 ];
 
 dbgpRunFile( $filename, $commands, $settings );

--- a/tests/debugger/bug01931-002.phpt
+++ b/tests/debugger/bug01931-002.phpt
@@ -1,7 +1,5 @@
 --TEST--
 Test for bug #1931: No local variables with trigger and xdebug_break() [2]
---XFAIL--
-Phase 2 RINIT observer gating sets observer_active=0 when no debug client connects at RINIT. Without observer callbacks, the stack vector is empty, so xdebug_break()/connect_to_client() cannot report stack frames. Trade-off: 0% overhead when no client vs working mid-request activation.
 --SKIPIF--
 <?php
 require __DIR__ . '/../utils.inc';
@@ -29,6 +27,7 @@ $commands = array(
 $settings = [
 	'xdebug.mode' => 'debug',
 	'xdebug.start_with_request' => 'trigger',
+	'xdebug.jit_debugging_enabled' => 1
 ];
 
 dbgpRunFile( $filename, $commands, $settings );

--- a/tests/debugger/bug01931-002.phpt
+++ b/tests/debugger/bug01931-002.phpt
@@ -27,7 +27,7 @@ $commands = array(
 $settings = [
 	'xdebug.mode' => 'debug',
 	'xdebug.start_with_request' => 'trigger',
-	'xdebug.jit_debugging_enabled' => 1
+	'xdebug.on_demand_debugging_enabled' => 1
 ];
 
 dbgpRunFile( $filename, $commands, $settings );

--- a/tests/debugger/bug01931-003.phpt
+++ b/tests/debugger/bug01931-003.phpt
@@ -1,7 +1,5 @@
 --TEST--
 Test for bug #1931: No local variables with trigger and xdebug_break() [3]
---XFAIL--
-Phase 2 RINIT observer gating sets observer_active=0 when no debug client connects at RINIT. Without observer callbacks, the stack vector is empty, so xdebug_break()/connect_to_client() cannot report stack frames. Trade-off: 0% overhead when no client vs working mid-request activation.
 --SKIPIF--
 <?php
 require __DIR__ . '/../utils.inc';
@@ -25,6 +23,7 @@ $commands = array(
 $settings = [
 	'xdebug.mode' => 'debug',
 	'xdebug.start_with_request' => 'trigger',
+	'xdebug.jit_debugging_enabled' => 1
 ];
 
 dbgpRunFile( $filename, $commands, $settings );

--- a/tests/debugger/bug01931-003.phpt
+++ b/tests/debugger/bug01931-003.phpt
@@ -23,7 +23,7 @@ $commands = array(
 $settings = [
 	'xdebug.mode' => 'debug',
 	'xdebug.start_with_request' => 'trigger',
-	'xdebug.jit_debugging_enabled' => 1
+	'xdebug.on_demand_debugging_enabled' => 1
 ];
 
 dbgpRunFile( $filename, $commands, $settings );

--- a/tests/debugger/bug02122.phpt
+++ b/tests/debugger/bug02122.phpt
@@ -1,7 +1,5 @@
 --TEST--
 Test for bug #2122: Local variables are not available when using start_upon_error
---XFAIL--
-Phase 2 RINIT observer gating sets observer_active=0 when no debug client connects at RINIT. When an error triggers debugging mid-request, the observer has not been tracking function calls, so stack frames and local variables are unavailable (error 301: stack depth invalid).
 --SKIPIF--
 <?php
 require __DIR__ . '/../utils.inc';
@@ -18,7 +16,11 @@ $commands = array(
 	'detach',
 );
 
-dbgpRunFile( $filename, $commands, [ 'xdebug.start_with_request' => 'default', 'xdebug.start_upon_error' => 'yes' ] );
+dbgpRunFile( $filename, $commands, [
+	'xdebug.start_with_request' => 'default',
+	'xdebug.start_upon_error' => 'yes',
+	'xdebug.jit_debugging_enabled' => 1
+]);
 ?>
 --EXPECTF--
 <?xml version="1.0" encoding="iso-8859-1"?>

--- a/tests/debugger/bug02122.phpt
+++ b/tests/debugger/bug02122.phpt
@@ -19,7 +19,7 @@ $commands = array(
 dbgpRunFile( $filename, $commands, [
 	'xdebug.start_with_request' => 'default',
 	'xdebug.start_upon_error' => 'yes',
-	'xdebug.jit_debugging_enabled' => 1
+	'xdebug.on_demand_debugging_enabled' => 1
 ]);
 ?>
 --EXPECTF--

--- a/tests/debugger/start_ignore_no_cookie.phpt
+++ b/tests/debugger/start_ignore_no_cookie.phpt
@@ -1,7 +1,5 @@
 --TEST--
 Starting Debugger: overridden COOKIE ignore value is 'no'
---XFAIL--
-Phase 2 RINIT gating calls xdebug_should_ignore() at RINIT time. These tests use auto_prepend_file PHP code to set $_COOKIE/$_GET/$_POST, which only executes after RINIT. At RINIT, only getenv() works, so the superglobal override is never seen. Real HTTP headers in CGI/FPM ARE available at RINIT and work correctly.
 --FILE--
 <?php
 require 'dbgp/dbgpclient.php';
@@ -15,6 +13,7 @@ dbgpRunFile(
 	[
 		'xdebug.mode' => 'debug', 'xdebug.start_with_request' => 'yes',
 		'xdebug.log' => $xdebugLogFileName, 'xdebug.log_level' => 10,
+		'xdebug.jit_debugging_enabled' => 1
 	],
 	['timeout' => 1, 'env' => [ 'XDEBUG_IGNORE' => 'yes' ], 'auto_prepend' => '<?php $_COOKIE["XDEBUG_IGNORE"] = "no";']
 );

--- a/tests/debugger/start_ignore_no_cookie.phpt
+++ b/tests/debugger/start_ignore_no_cookie.phpt
@@ -13,7 +13,7 @@ dbgpRunFile(
 	[
 		'xdebug.mode' => 'debug', 'xdebug.start_with_request' => 'yes',
 		'xdebug.log' => $xdebugLogFileName, 'xdebug.log_level' => 10,
-		'xdebug.jit_debugging_enabled' => 1
+		'xdebug.on_demand_debugging_enabled' => 1
 	],
 	['timeout' => 1, 'env' => [ 'XDEBUG_IGNORE' => 'yes' ], 'auto_prepend' => '<?php $_COOKIE["XDEBUG_IGNORE"] = "no";']
 );

--- a/tests/debugger/start_ignore_no_get.phpt
+++ b/tests/debugger/start_ignore_no_get.phpt
@@ -13,7 +13,7 @@ dbgpRunFile(
 	[
 		'xdebug.mode' => 'debug', 'xdebug.start_with_request' => 'yes',
 		'xdebug.log' => $xdebugLogFileName, 'xdebug.log_level' => 10,
-		'xdebug.jit_debugging_enabled' => 1
+		'xdebug.on_demand_debugging_enabled' => 1
 	],
 	['timeout' => 1, 'env' => [ 'XDEBUG_IGNORE' => 'yes' ], 'auto_prepend' => '<?php $_GET["XDEBUG_IGNORE"] = "no";']
 );

--- a/tests/debugger/start_ignore_no_get.phpt
+++ b/tests/debugger/start_ignore_no_get.phpt
@@ -1,7 +1,5 @@
 --TEST--
 Starting Debugger: overridden GET ignore value is 'no'
---XFAIL--
-Phase 2 RINIT gating calls xdebug_should_ignore() at RINIT time. These tests use auto_prepend_file PHP code to set $_COOKIE/$_GET/$_POST, which only executes after RINIT. At RINIT, only getenv() works, so the superglobal override is never seen. Real HTTP headers in CGI/FPM ARE available at RINIT and work correctly.
 --FILE--
 <?php
 require 'dbgp/dbgpclient.php';
@@ -15,6 +13,7 @@ dbgpRunFile(
 	[
 		'xdebug.mode' => 'debug', 'xdebug.start_with_request' => 'yes',
 		'xdebug.log' => $xdebugLogFileName, 'xdebug.log_level' => 10,
+		'xdebug.jit_debugging_enabled' => 1
 	],
 	['timeout' => 1, 'env' => [ 'XDEBUG_IGNORE' => 'yes' ], 'auto_prepend' => '<?php $_GET["XDEBUG_IGNORE"] = "no";']
 );

--- a/tests/debugger/start_ignore_no_post.phpt
+++ b/tests/debugger/start_ignore_no_post.phpt
@@ -13,7 +13,7 @@ dbgpRunFile(
 	[
 		'xdebug.mode' => 'debug', 'xdebug.start_with_request' => 'yes',
 		'xdebug.log' => $xdebugLogFileName, 'xdebug.log_level' => 10,
-		'xdebug.jit_debugging_enabled' => 1
+		'xdebug.on_demand_debugging_enabled' => 1
 	],
 	['timeout' => 1, 'env' => [ 'XDEBUG_IGNORE' => 'yes' ], 'auto_prepend' => '<?php $_POST["XDEBUG_IGNORE"] = "no";']
 );

--- a/tests/debugger/start_ignore_no_post.phpt
+++ b/tests/debugger/start_ignore_no_post.phpt
@@ -1,7 +1,5 @@
 --TEST--
 Starting Debugger: overridden POST ignore value is 'no'
---XFAIL--
-Phase 2 RINIT gating calls xdebug_should_ignore() at RINIT time. These tests use auto_prepend_file PHP code to set $_COOKIE/$_GET/$_POST, which only executes after RINIT. At RINIT, only getenv() works, so the superglobal override is never seen. Real HTTP headers in CGI/FPM ARE available at RINIT and work correctly.
 --FILE--
 <?php
 require 'dbgp/dbgpclient.php';
@@ -15,6 +13,7 @@ dbgpRunFile(
 	[
 		'xdebug.mode' => 'debug', 'xdebug.start_with_request' => 'yes',
 		'xdebug.log' => $xdebugLogFileName, 'xdebug.log_level' => 10,
+		'xdebug.jit_debugging_enabled' => 1
 	],
 	['timeout' => 1, 'env' => [ 'XDEBUG_IGNORE' => 'yes' ], 'auto_prepend' => '<?php $_POST["XDEBUG_IGNORE"] = "no";']
 );

--- a/tests/debugger/start_ignore_yes_cookie.phpt
+++ b/tests/debugger/start_ignore_yes_cookie.phpt
@@ -1,7 +1,5 @@
 --TEST--
 Starting Debugger: overridden COOKIE ignore value is 'yes'
---XFAIL--
-Phase 2 RINIT gating calls xdebug_should_ignore() at RINIT time. These tests use auto_prepend_file PHP code to set $_COOKIE/$_GET/$_POST, which only executes after RINIT. At RINIT, only getenv() works, so the superglobal override is never seen. Real HTTP headers in CGI/FPM ARE available at RINIT and work correctly.
 --FILE--
 <?php
 require 'dbgp/dbgpclient.php';
@@ -15,6 +13,7 @@ dbgpRunFile(
 	[
 		'xdebug.mode' => 'debug', 'xdebug.start_with_request' => 'yes',
 		'xdebug.log' => $xdebugLogFileName, 'xdebug.log_level' => 10,
+		'xdebug.jit_debugging_enabled' => 1
 	],
 	['timeout' => 1, 'env' => [ 'XDEBUG_IGNORE' => 'yes' ], 'auto_prepend' => '<?php $_COOKIE["XDEBUG_IGNORE"] = "yes";']
 );

--- a/tests/debugger/start_ignore_yes_cookie.phpt
+++ b/tests/debugger/start_ignore_yes_cookie.phpt
@@ -13,7 +13,7 @@ dbgpRunFile(
 	[
 		'xdebug.mode' => 'debug', 'xdebug.start_with_request' => 'yes',
 		'xdebug.log' => $xdebugLogFileName, 'xdebug.log_level' => 10,
-		'xdebug.jit_debugging_enabled' => 1
+		'xdebug.on_demand_debugging_enabled' => 1
 	],
 	['timeout' => 1, 'env' => [ 'XDEBUG_IGNORE' => 'yes' ], 'auto_prepend' => '<?php $_COOKIE["XDEBUG_IGNORE"] = "yes";']
 );

--- a/tests/debugger/start_ignore_yes_env.phpt
+++ b/tests/debugger/start_ignore_yes_env.phpt
@@ -15,6 +15,7 @@ dbgpRunFile(
 	[
 		'xdebug.mode' => 'debug', 'xdebug.start_with_request' => 'yes',
 		'xdebug.log' => $xdebugLogFileName, 'xdebug.log_level' => 10,
+		'xdebug.jit_debugging_enabled' => 1
 	],
 	['timeout' => 1, 'env' => ['XDEBUG_IGNORE' => 'yes']]
 );

--- a/tests/debugger/start_ignore_yes_env.phpt
+++ b/tests/debugger/start_ignore_yes_env.phpt
@@ -15,7 +15,7 @@ dbgpRunFile(
 	[
 		'xdebug.mode' => 'debug', 'xdebug.start_with_request' => 'yes',
 		'xdebug.log' => $xdebugLogFileName, 'xdebug.log_level' => 10,
-		'xdebug.jit_debugging_enabled' => 1
+		'xdebug.on_demand_debugging_enabled' => 1
 	],
 	['timeout' => 1, 'env' => ['XDEBUG_IGNORE' => 'yes']]
 );

--- a/tests/debugger/start_ignore_yes_get.phpt
+++ b/tests/debugger/start_ignore_yes_get.phpt
@@ -1,7 +1,5 @@
 --TEST--
 Starting Debugger: overridden GET ignore value is 'yes'
---XFAIL--
-Phase 2 RINIT gating calls xdebug_should_ignore() at RINIT time. These tests use auto_prepend_file PHP code to set $_COOKIE/$_GET/$_POST, which only executes after RINIT. At RINIT, only getenv() works, so the superglobal override is never seen. Real HTTP headers in CGI/FPM ARE available at RINIT and work correctly.
 --FILE--
 <?php
 require 'dbgp/dbgpclient.php';
@@ -15,6 +13,7 @@ dbgpRunFile(
 	[
 		'xdebug.mode' => 'debug', 'xdebug.start_with_request' => 'yes',
 		'xdebug.log' => $xdebugLogFileName, 'xdebug.log_level' => 10,
+		'xdebug.jit_debugging_enabled' => 1
 	],
 	['timeout' => 1, 'env' => [ 'XDEBUG_IGNORE' => 'yes' ], 'auto_prepend' => '<?php $_GET["XDEBUG_IGNORE"] = "yes";']
 );

--- a/tests/debugger/start_ignore_yes_get.phpt
+++ b/tests/debugger/start_ignore_yes_get.phpt
@@ -13,7 +13,7 @@ dbgpRunFile(
 	[
 		'xdebug.mode' => 'debug', 'xdebug.start_with_request' => 'yes',
 		'xdebug.log' => $xdebugLogFileName, 'xdebug.log_level' => 10,
-		'xdebug.jit_debugging_enabled' => 1
+		'xdebug.on_demand_debugging_enabled' => 1
 	],
 	['timeout' => 1, 'env' => [ 'XDEBUG_IGNORE' => 'yes' ], 'auto_prepend' => '<?php $_GET["XDEBUG_IGNORE"] = "yes";']
 );

--- a/tests/debugger/start_ignore_yes_post.phpt
+++ b/tests/debugger/start_ignore_yes_post.phpt
@@ -13,7 +13,7 @@ dbgpRunFile(
 	[
 		'xdebug.mode' => 'debug', 'xdebug.start_with_request' => 'yes',
 		'xdebug.log' => $xdebugLogFileName, 'xdebug.log_level' => 10,
-		'xdebug.jit_debugging_enabled' => 1
+		'xdebug.on_demand_debugging_enabled' => 1
 	],
 	['timeout' => 1, 'env' => [ 'XDEBUG_IGNORE' => 'yes' ], 'auto_prepend' => '<?php $_POST["XDEBUG_IGNORE"] = "yes";']
 );

--- a/tests/debugger/start_ignore_yes_post.phpt
+++ b/tests/debugger/start_ignore_yes_post.phpt
@@ -1,7 +1,5 @@
 --TEST--
 Starting Debugger: overridden POST ignore value is 'yes'
---XFAIL--
-Phase 2 RINIT gating calls xdebug_should_ignore() at RINIT time. These tests use auto_prepend_file PHP code to set $_COOKIE/$_GET/$_POST, which only executes after RINIT. At RINIT, only getenv() works, so the superglobal override is never seen. Real HTTP headers in CGI/FPM ARE available at RINIT and work correctly.
 --FILE--
 <?php
 require 'dbgp/dbgpclient.php';
@@ -15,6 +13,7 @@ dbgpRunFile(
 	[
 		'xdebug.mode' => 'debug', 'xdebug.start_with_request' => 'yes',
 		'xdebug.log' => $xdebugLogFileName, 'xdebug.log_level' => 10,
+		'xdebug.jit_debugging_enabled' => 1
 	],
 	['timeout' => 1, 'env' => [ 'XDEBUG_IGNORE' => 'yes' ], 'auto_prepend' => '<?php $_POST["XDEBUG_IGNORE"] = "yes";']
 );

--- a/tests/debugger/start_upon_error_trigger_error.phpt
+++ b/tests/debugger/start_upon_error_trigger_error.phpt
@@ -1,7 +1,5 @@
 --TEST--
 Starting Debugger: trigger, error, start_up_error=yes
---XFAIL--
-Phase 2 RINIT observer gating sets observer_active=0 when no debug client connects at RINIT. When an error triggers debugging mid-request, the observer has not been tracking function calls, so stack frames and local variables are unavailable (error 301: stack depth invalid).
 --FILE--
 <?php
 require 'dbgp/dbgpclient.php';
@@ -9,7 +7,12 @@ require 'dbgp/dbgpclient.php';
 dbgpRunFile(
 	dirname(__FILE__) . '/break-with-error.inc',
 	['stack_get', 'step_into', 'detach'],
-	['xdebug.mode' => 'debug', 'xdebug.start_with_request' => 'trigger', 'xdebug.start_upon_error' => 'yes'],
+	[
+		'xdebug.mode' => 'debug',
+		'xdebug.start_with_request' => 'trigger',
+		'xdebug.start_upon_error' => 'yes',
+		'xdebug.jit_debugging_enabled' => 1
+	],
 	['timeout' => 1]
 );
 ?>

--- a/tests/debugger/start_upon_error_trigger_error.phpt
+++ b/tests/debugger/start_upon_error_trigger_error.phpt
@@ -11,7 +11,7 @@ dbgpRunFile(
 		'xdebug.mode' => 'debug',
 		'xdebug.start_with_request' => 'trigger',
 		'xdebug.start_upon_error' => 'yes',
-		'xdebug.jit_debugging_enabled' => 1
+		'xdebug.on_demand_debugging_enabled' => 1
 	],
 	['timeout' => 1]
 );

--- a/tests/debugger/start_with_request_default_break.phpt
+++ b/tests/debugger/start_with_request_default_break.phpt
@@ -1,7 +1,5 @@
 --TEST--
 Starting Debugger: default, break
---XFAIL--
-Phase 2 RINIT observer gating sets observer_active=0 when no debug client connects at RINIT. Without observer callbacks, the stack vector is empty, so xdebug_break()/connect_to_client() cannot report stack frames. Trade-off: 0% overhead when no client vs working mid-request activation.
 --FILE--
 <?php
 require 'dbgp/dbgpclient.php';
@@ -9,7 +7,11 @@ require 'dbgp/dbgpclient.php';
 dbgpRunFile(
 	dirname(__FILE__) . '/break-echo.inc',
 	['stack_get', 'step_into', 'detach'],
-	['xdebug.mode' => 'debug', 'xdebug.start_with_request' => 'default']
+	[
+		'xdebug.mode' => 'debug',
+		'xdebug.start_with_request' => 'default',
+		'xdebug.jit_debugging_enabled' => 1
+	]
 );
 ?>
 --EXPECTF--

--- a/tests/debugger/start_with_request_default_break.phpt
+++ b/tests/debugger/start_with_request_default_break.phpt
@@ -10,7 +10,7 @@ dbgpRunFile(
 	[
 		'xdebug.mode' => 'debug',
 		'xdebug.start_with_request' => 'default',
-		'xdebug.jit_debugging_enabled' => 1
+		'xdebug.on_demand_debugging_enabled' => 1
 	]
 );
 ?>

--- a/tests/debugger/start_with_request_default_config.phpt
+++ b/tests/debugger/start_with_request_default_config.phpt
@@ -12,7 +12,7 @@ dbgpRunFile(
 	[
 		'xdebug.mode' => 'debug',
 		'xdebug.start_with_request' => 'default',
-		'xdebug.jit_debugging_enabled' => 1
+		'xdebug.on_demand_debugging_enabled' => 1
 	]
 );
 ?>

--- a/tests/debugger/start_with_request_default_config.phpt
+++ b/tests/debugger/start_with_request_default_config.phpt
@@ -1,7 +1,5 @@
 --TEST--
 Starting Debugger: default, XDEBUG_CONFIG=idekey=foobar
---XFAIL--
-Phase 2 RINIT observer gating sets observer_active=0 when no debug client connects at RINIT. Without observer callbacks, the stack vector is empty, so xdebug_break()/connect_to_client() cannot report stack frames. Trade-off: 0% overhead when no client vs working mid-request activation.
 --ENV--
 XDEBUG_CONFIG=idekey=foobar
 --FILE--
@@ -11,7 +9,11 @@ require 'dbgp/dbgpclient.php';
 dbgpRunFile(
 	dirname(__FILE__) . '/empty-echo.inc',
 	['step_into', 'step_into', 'property_get -n $e', 'detach'],
-	['xdebug.mode' => 'debug', 'xdebug.start_with_request' => 'default']
+	[
+		'xdebug.mode' => 'debug',
+		'xdebug.start_with_request' => 'default',
+		'xdebug.jit_debugging_enabled' => 1
+	]
 );
 ?>
 --EXPECTF--

--- a/tests/debugger/start_with_request_never_break.phpt
+++ b/tests/debugger/start_with_request_never_break.phpt
@@ -10,7 +10,7 @@ dbgpRunFile(
 	[
 		'xdebug.mode' => 'debug',
 		'xdebug.start_with_request' => 'no',
-		'xdebug.jit_debugging_enabled' => 1
+		'xdebug.on_demand_debugging_enabled' => 1
 	],
 	['timeout' => 1]
 );

--- a/tests/debugger/start_with_request_never_break.phpt
+++ b/tests/debugger/start_with_request_never_break.phpt
@@ -7,7 +7,11 @@ require 'dbgp/dbgpclient.php';
 dbgpRunFile(
 	dirname(__FILE__) . '/break-echo.inc',
 	['stack_get', 'step_into', 'detach'],
-	['xdebug.mode' => 'debug', 'xdebug.start_with_request' => 'no'],
+	[
+		'xdebug.mode' => 'debug',
+		'xdebug.start_with_request' => 'no',
+		'xdebug.jit_debugging_enabled' => 1
+	],
 	['timeout' => 1]
 );
 ?>

--- a/tests/debugger/start_with_request_never_break_session_start.phpt
+++ b/tests/debugger/start_with_request_never_break_session_start.phpt
@@ -12,7 +12,7 @@ dbgpRunFile(
 	[
 		'xdebug.mode' => 'debug',
 	 	'xdebug.start_with_request' => 'no',
-		'xdebug.jit_debugging_enabled' => 1
+		'xdebug.on_demand_debugging_enabled' => 1
 	],
 	['timeout' => 1]
 );

--- a/tests/debugger/start_with_request_never_break_session_start.phpt
+++ b/tests/debugger/start_with_request_never_break_session_start.phpt
@@ -9,7 +9,11 @@ require 'dbgp/dbgpclient.php';
 dbgpRunFile(
 	dirname(__FILE__) . '/break-echo.inc',
 	['stack_get', 'step_into', 'detach'],
-	['xdebug.mode' => 'debug', 'xdebug.start_with_request' => 'no'],
+	[
+		'xdebug.mode' => 'debug',
+	 	'xdebug.start_with_request' => 'no',
+		'xdebug.jit_debugging_enabled' => 1
+	],
 	['timeout' => 1]
 );
 ?>

--- a/tests/debugger/start_with_request_trigger_break.phpt
+++ b/tests/debugger/start_with_request_trigger_break.phpt
@@ -10,7 +10,7 @@ dbgpRunFile(
 	[
 		'xdebug.mode' => 'debug',
 		'xdebug.start_with_request' => 'trigger',
-		'xdebug.jit_debugging_enabled' => 1
+		'xdebug.on_demand_debugging_enabled' => 1
 	]
 );
 ?>

--- a/tests/debugger/start_with_request_trigger_break.phpt
+++ b/tests/debugger/start_with_request_trigger_break.phpt
@@ -1,7 +1,5 @@
 --TEST--
 Starting Debugger: trigger, break
---XFAIL--
-Phase 2 RINIT observer gating sets observer_active=0 when no debug client connects at RINIT. Without observer callbacks, the stack vector is empty, so xdebug_break()/connect_to_client() cannot report stack frames. Trade-off: 0% overhead when no client vs working mid-request activation.
 --FILE--
 <?php
 require 'dbgp/dbgpclient.php';
@@ -9,7 +7,11 @@ require 'dbgp/dbgpclient.php';
 dbgpRunFile(
 	dirname(__FILE__) . '/break-echo.inc',
 	['stack_get', 'step_into', 'detach'],
-	['xdebug.mode' => 'debug', 'xdebug.start_with_request' => 'trigger']
+	[
+		'xdebug.mode' => 'debug',
+		'xdebug.start_with_request' => 'trigger',
+		'xdebug.jit_debugging_enabled' => 1
+	]
 );
 ?>
 --EXPECTF--

--- a/tests/debugger/start_with_request_trigger_config.phpt
+++ b/tests/debugger/start_with_request_trigger_config.phpt
@@ -1,7 +1,5 @@
 --TEST--
 Starting Debugger: trigger, XDEBUG_CONFIG=idekey=foobar
---XFAIL--
-Phase 2 RINIT observer gating sets observer_active=0 when no debug client connects at RINIT. Without observer callbacks, the stack vector is empty, so xdebug_break()/connect_to_client() cannot report stack frames. Trade-off: 0% overhead when no client vs working mid-request activation.
 --ENV--
 XDEBUG_CONFIG=idekey=foobar
 --FILE--
@@ -11,7 +9,11 @@ require 'dbgp/dbgpclient.php';
 dbgpRunFile(
 	dirname(__FILE__) . '/empty-echo.inc',
 	['step_into', 'step_into', 'property_get -n $e', 'detach'],
-	['xdebug.mode' => 'debug', 'xdebug.start_with_request' => 'trigger']
+	[
+		'xdebug.mode' => 'debug',
+		'xdebug.start_with_request' => 'trigger',
+		'xdebug.jit_debugging_enabled' => 1
+	]
 );
 ?>
 --EXPECTF--

--- a/tests/debugger/start_with_request_trigger_config.phpt
+++ b/tests/debugger/start_with_request_trigger_config.phpt
@@ -12,7 +12,7 @@ dbgpRunFile(
 	[
 		'xdebug.mode' => 'debug',
 		'xdebug.start_with_request' => 'trigger',
-		'xdebug.jit_debugging_enabled' => 1
+		'xdebug.on_demand_debugging_enabled' => 1
 	]
 );
 ?>

--- a/tests/debugger/start_with_request_trigger_session_start_shared_secret-001.phpt
+++ b/tests/debugger/start_with_request_trigger_session_start_shared_secret-001.phpt
@@ -20,6 +20,7 @@ dbgpRunFile(
 		'variables_order' => 'PGCS',
 		'xdebug.log' => $xdebugLogFileName, 'xdebug.log_level' => 10,
 		'xdebug.control_socket' => 'off', 'xdebug.path_mapping' => 'off',
+		'xdebug.jit_debugging_enabled' => 1
 	],
 	['timeout' => 1]
 );

--- a/tests/debugger/start_with_request_trigger_session_start_shared_secret-001.phpt
+++ b/tests/debugger/start_with_request_trigger_session_start_shared_secret-001.phpt
@@ -20,7 +20,7 @@ dbgpRunFile(
 		'variables_order' => 'PGCS',
 		'xdebug.log' => $xdebugLogFileName, 'xdebug.log_level' => 10,
 		'xdebug.control_socket' => 'off', 'xdebug.path_mapping' => 'off',
-		'xdebug.jit_debugging_enabled' => 1
+		'xdebug.on_demand_debugging_enabled' => 1
 	],
 	['timeout' => 1]
 );

--- a/tests/debugger/xdebug_connect_to_client.phpt
+++ b/tests/debugger/xdebug_connect_to_client.phpt
@@ -24,7 +24,7 @@ $commands = array(
 $settings = [
 	'xdebug.mode' => 'debug',
 	'xdebug.start_with_request' => 'trigger',
-	'xdebug.jit_debugging_enabled' => 1
+	'xdebug.on_demand_debugging_enabled' => 1
 ];
 
 dbgpRunFile( $filename, $commands, $settings );

--- a/tests/debugger/xdebug_connect_to_client.phpt
+++ b/tests/debugger/xdebug_connect_to_client.phpt
@@ -1,7 +1,5 @@
 --TEST--
 xdebug_connect_to_client()
---XFAIL--
-Phase 2 RINIT observer gating sets observer_active=0 when no debug client connects at RINIT. Without observer callbacks, the stack vector is empty, so xdebug_break()/connect_to_client() cannot report stack frames. Trade-off: 0% overhead when no client vs working mid-request activation.
 --SKIPIF--
 <?php
 require __DIR__ . '/../utils.inc';
@@ -26,6 +24,7 @@ $commands = array(
 $settings = [
 	'xdebug.mode' => 'debug',
 	'xdebug.start_with_request' => 'trigger',
+	'xdebug.jit_debugging_enabled' => 1
 ];
 
 dbgpRunFile( $filename, $commands, $settings );

--- a/tests/debugger/xdebug_notify-002.phpt
+++ b/tests/debugger/xdebug_notify-002.phpt
@@ -1,10 +1,5 @@
 --TEST--
 xdebug_notify() without a debugging session active
---SKIPIF--
-<?php
-require __DIR__ . "/../utils.inc";
-if (is_stripped_debugger()) die("skip Uses xdebug_notify (removed)");
-?>
 --INI--
 xdebug.mode=debug
 --FILE--

--- a/xdebug.c
+++ b/xdebug.c
@@ -685,10 +685,6 @@ ZEND_DLEXPORT void xdebug_statement_call(zend_execute_data *frame)
 		return;
 	}
 
-	if (!XG_BASE(statement_handler_enabled)) {
-		return;
-	}
-
 	if (!EG(current_execute_data)) {
 		return;
 	}
@@ -696,6 +692,10 @@ ZEND_DLEXPORT void xdebug_statement_call(zend_execute_data *frame)
 #if HAVE_XDEBUG_CONTROL_SOCKET_SUPPORT
 	xdebug_control_socket_dispatch();
 #endif
+
+	if (!XG_BASE(statement_handler_enabled)) {
+		return;
+	}
 
 	op_array = &frame->func->op_array;
 	lineno = EG(current_execute_data)->opline->lineno;
@@ -741,6 +741,14 @@ ZEND_DLEXPORT void xdebug_zend_shutdown(zend_extension *extension)
 	xdebug_library_zend_shutdown();
 }
 
+ZEND_DLEXPORT void xdebug_init_oparray(zend_op_array *op_array)
+{
+	if (XDEBUG_MODE_IS_OFF()) {
+		return;
+	}
+
+}
+
 #ifndef ZEND_EXT_API
 #define ZEND_EXT_API    ZEND_DLEXPORT
 #endif
@@ -762,7 +770,7 @@ ZEND_DLEXPORT zend_extension zend_extension_entry = {
 	xdebug_statement_call, /* statement_handler_func_t */
 	NULL,           /* fcall_begin_handler_func_t */
 	NULL,           /* fcall_end_handler_func_t */
-	NULL,           /* op_array_ctor_func_t */
+	xdebug_init_oparray,   /* op_array_ctor_func_t */
 	NULL,           /* op_array_dtor_func_t */
 	STANDARD_ZEND_EXTENSION_PROPERTIES
 };

--- a/xdebug.c
+++ b/xdebug.c
@@ -305,6 +305,7 @@ PHP_INI_BEGIN()
 	STD_PHP_INI_ENTRY("xdebug.client_discovery_header", "HTTP_X_FORWARDED_FOR,REMOTE_ADDR", PHP_INI_ALL, OnUpdateString, settings.debugger.client_discovery_header, zend_xdebug_globals, xdebug_globals)
 	STD_PHP_INI_ENTRY("xdebug.idekey",                  "",                                 PHP_INI_ALL, OnUpdateString, settings.debugger.ide_key_setting,         zend_xdebug_globals, xdebug_globals)
 	STD_PHP_INI_ENTRY("xdebug.connect_timeout_ms",      "200",                              PHP_INI_ALL, OnUpdateLong,   settings.debugger.connect_timeout_ms,      zend_xdebug_globals, xdebug_globals)
+	STD_PHP_INI_BOOLEAN("xdebug.jit_debugging_enabled", "0",                                PHP_INI_SYSTEM, OnUpdateBool,settings.debugger.jit_debugging_enabled,   zend_xdebug_globals, xdebug_globals)
 
 PHP_INI_END()
 
@@ -340,6 +341,7 @@ static const zend_ini_entry_def php_debugger_ini_entries[] = {
 	STD_PHP_INI_ENTRY("php_debugger.client_discovery_header", "HTTP_X_FORWARDED_FOR,REMOTE_ADDR", PHP_INI_ALL, OnUpdatePhpDebuggerString, settings.debugger.client_discovery_header, zend_xdebug_globals, xdebug_globals)
 	STD_PHP_INI_ENTRY("php_debugger.idekey",                  "",                                 PHP_INI_ALL, OnUpdatePhpDebuggerString, settings.debugger.ide_key_setting,         zend_xdebug_globals, xdebug_globals)
 	STD_PHP_INI_ENTRY("php_debugger.connect_timeout_ms",      "200",                              PHP_INI_ALL, OnUpdatePhpDebuggerLong,   settings.debugger.connect_timeout_ms,      zend_xdebug_globals, xdebug_globals)
+	STD_PHP_INI_BOOLEAN("php_debugger.jit_debugging_enabled", "0",                                PHP_INI_SYSTEM, OnUpdatePhpDebuggerBool,settings.debugger.jit_debugging_enabled,   zend_xdebug_globals, xdebug_globals)
 	{0}
 };
 
@@ -354,6 +356,7 @@ static void xdebug_init_base_globals(xdebug_base_globals_t *xg)
 	xg->error_reporting_override   = 0;
 	xg->error_reporting_overridden = 0;
 	xg->statement_handler_enabled  = false;
+	xg->early_connection = false;
 
 	xg->filter_type_stack         = XDEBUG_FILTER_NONE;
 	xg->filters_stack             = NULL;
@@ -415,6 +418,9 @@ static void xdebug_env_config(void)
 
 		if (strcasecmp(envvar, "discover_client_host") == 0) {
 			name = "xdebug.discover_client_host";
+		} else
+		if (strcasecmp(envvar, "jit_debugging_enabled") == 0) {
+			name = "xdebug.jit_debugging_enabled";
 		} else
 		if (strcasecmp(envvar, "client_port") == 0) {
 			name = "xdebug.client_port";
@@ -577,11 +583,11 @@ PHP_RINIT_FUNCTION(xdebug)
 
 	xdebug_init_auto_globals();
 
+	xdebug_base_rinit();
+
 	/* Early debug init: attempt connection at RINIT so observer_active is set
 	 * before any user code runs. This allows xdebug_observer_init to return
 	 * {NULL, NULL} for functions first-called when no debugger is connected. */
-	xdebug_base_rinit();
-
 	if (XDEBUG_MODE_IS(XDEBUG_MODE_STEP_DEBUG)) {
 		/* Check early if debugging could be requested this request.
 		 * For start_with_request=default (trigger mode), check if any
@@ -603,26 +609,25 @@ PHP_RINIT_FUNCTION(xdebug)
 			getenv("PHP_DEBUGGER_SESSION_START") != NULL
 		);
 
+		int connected = false;
 		if (debug_requested) {
 			/* Debug session requested: check if a client is actually listening
 			 * before enabling expensive EXT_STMT opcodes. This avoids ~2x
 			 * overhead when triggers are present but no IDE is connected. */
 			if (xdebug_early_connect_to_client()) {
-				CG(compiler_options) = CG(compiler_options) | ZEND_COMPILE_EXTENDED_STMT;
-			} else {
-				/* Trigger present but no client listening — stay dormant */
-				XG_BASE(observer_active) = 0;
-				XG_BASE(statement_handler_enabled) = false;
+				connected = true;
 			}
-		} else {
-			/* No debug trigger: disable all heavy hooks for near-zero overhead.
-			 * Note: xdebug_break() jit mode won't have full stepping support
-			 * without EXT_STMT opcodes. Use start_with_request=yes or a trigger
-			 * for full debugging support. */
-			XG_BASE(observer_active) = 0;
+			XG_BASE(early_connection) = 1;
+		}
+		if (!connected) {
+			if (!XINI_DBG(jit_debugging_enabled)) {
+                XG_BASE(observer_active) = false;
+                return SUCCESS;
+		    }
 			XG_BASE(statement_handler_enabled) = false;
 		}
 	}
+	xdebug_base_rinit_if_enabled();
 
 	return SUCCESS;
 }
@@ -680,6 +685,10 @@ ZEND_DLEXPORT void xdebug_statement_call(zend_execute_data *frame)
 		return;
 	}
 
+	if (!XG_BASE(statement_handler_enabled)) {
+		return;
+	}
+
 	if (!EG(current_execute_data)) {
 		return;
 	}
@@ -687,10 +696,6 @@ ZEND_DLEXPORT void xdebug_statement_call(zend_execute_data *frame)
 #if HAVE_XDEBUG_CONTROL_SOCKET_SUPPORT
 	xdebug_control_socket_dispatch();
 #endif
-
-	if (!XG_BASE(statement_handler_enabled)) {
-		return;
-	}
 
 	op_array = &frame->func->op_array;
 	lineno = EG(current_execute_data)->opline->lineno;

--- a/xdebug.c
+++ b/xdebug.c
@@ -305,7 +305,7 @@ PHP_INI_BEGIN()
 	STD_PHP_INI_ENTRY("xdebug.client_discovery_header", "HTTP_X_FORWARDED_FOR,REMOTE_ADDR", PHP_INI_ALL, OnUpdateString, settings.debugger.client_discovery_header, zend_xdebug_globals, xdebug_globals)
 	STD_PHP_INI_ENTRY("xdebug.idekey",                  "",                                 PHP_INI_ALL, OnUpdateString, settings.debugger.ide_key_setting,         zend_xdebug_globals, xdebug_globals)
 	STD_PHP_INI_ENTRY("xdebug.connect_timeout_ms",      "200",                              PHP_INI_ALL, OnUpdateLong,   settings.debugger.connect_timeout_ms,      zend_xdebug_globals, xdebug_globals)
-	STD_PHP_INI_BOOLEAN("xdebug.jit_debugging_enabled", "0",                                PHP_INI_SYSTEM, OnUpdateBool,settings.debugger.jit_debugging_enabled,   zend_xdebug_globals, xdebug_globals)
+	STD_PHP_INI_BOOLEAN("xdebug.on_demand_debugging_enabled", "0",                                PHP_INI_SYSTEM, OnUpdateBool,settings.debugger.on_demand_debugging_enabled,   zend_xdebug_globals, xdebug_globals)
 
 PHP_INI_END()
 
@@ -341,7 +341,7 @@ static const zend_ini_entry_def php_debugger_ini_entries[] = {
 	STD_PHP_INI_ENTRY("php_debugger.client_discovery_header", "HTTP_X_FORWARDED_FOR,REMOTE_ADDR", PHP_INI_ALL, OnUpdatePhpDebuggerString, settings.debugger.client_discovery_header, zend_xdebug_globals, xdebug_globals)
 	STD_PHP_INI_ENTRY("php_debugger.idekey",                  "",                                 PHP_INI_ALL, OnUpdatePhpDebuggerString, settings.debugger.ide_key_setting,         zend_xdebug_globals, xdebug_globals)
 	STD_PHP_INI_ENTRY("php_debugger.connect_timeout_ms",      "200",                              PHP_INI_ALL, OnUpdatePhpDebuggerLong,   settings.debugger.connect_timeout_ms,      zend_xdebug_globals, xdebug_globals)
-	STD_PHP_INI_BOOLEAN("php_debugger.jit_debugging_enabled", "0",                                PHP_INI_SYSTEM, OnUpdatePhpDebuggerBool,settings.debugger.jit_debugging_enabled,   zend_xdebug_globals, xdebug_globals)
+	STD_PHP_INI_BOOLEAN("php_debugger.on_demand_debugging_enabled", "0",                                PHP_INI_SYSTEM, OnUpdatePhpDebuggerBool,settings.debugger.on_demand_debugging_enabled,   zend_xdebug_globals, xdebug_globals)
 	{0}
 };
 
@@ -419,8 +419,8 @@ static void xdebug_env_config(void)
 		if (strcasecmp(envvar, "discover_client_host") == 0) {
 			name = "xdebug.discover_client_host";
 		} else
-		if (strcasecmp(envvar, "jit_debugging_enabled") == 0) {
-			name = "xdebug.jit_debugging_enabled";
+		if (strcasecmp(envvar, "on_demand_debugging_enabled") == 0) {
+			name = "xdebug.on_demand_debugging_enabled";
 		} else
 		if (strcasecmp(envvar, "client_port") == 0) {
 			name = "xdebug.client_port";
@@ -620,7 +620,7 @@ PHP_RINIT_FUNCTION(xdebug)
 			XG_BASE(early_connection) = 1;
 		}
 		if (!connected) {
-			if (!XINI_DBG(jit_debugging_enabled)) {
+			if (!XINI_DBG(on_demand_debugging_enabled)) {
                 XG_BASE(observer_active) = false;
                 return SUCCESS;
 		    }

--- a/xdebug.c
+++ b/xdebug.c
@@ -621,9 +621,9 @@ PHP_RINIT_FUNCTION(xdebug)
 		}
 		if (!connected) {
 			if (!XINI_DBG(on_demand_debugging_enabled)) {
-                XG_BASE(observer_active) = false;
-                return SUCCESS;
-		    }
+				XG_BASE(observer_active) = false;
+				return SUCCESS;
+			}
 			XG_BASE(statement_handler_enabled) = false;
 		}
 	}

--- a/xdebug.ini
+++ b/xdebug.ini
@@ -303,6 +303,30 @@
 ;xdebug.discover_client_host = false
 
 ; -----------------------------------------------------------------------------
+; xdebug.jit_debugging_enabled
+;
+; Type: boolean, Default value: false
+;
+; If disabled and no connection is made when the request starts, PHP Debugger will
+; completely disable the debugger so that trying to start it later with xdebug_break(),
+; xdebug_connect_to_client(), or start on error or exception will not work. This provides
+; almost 0% overhead for this case
+;
+; If you need the just in time debugging capabilities, set this flag to true. In this case
+; the debugger will not be fully disabled if no connection is made at the start of the
+; request and the overhead will be much larger. Only enable this option if you really require
+; these jit debugging capabilities
+;;
+; .. note::
+;
+;    This setting can additionally be configured through the
+;    ``XDEBUG_CONFIG``environment variable [1]. [1]
+;    /docs/all_settings#XDEBUG_CONFIG
+;
+;
+;xdebug.jit_debugging_enabled = false
+
+; -----------------------------------------------------------------------------
 ; xdebug.dump.*
 ;
 ; Type: string, Default value: Empty

--- a/xdebug.ini
+++ b/xdebug.ini
@@ -303,7 +303,7 @@
 ;xdebug.discover_client_host = false
 
 ; -----------------------------------------------------------------------------
-; xdebug.jit_debugging_enabled
+; xdebug.on_demand_debugging_enabled
 ;
 ; Type: boolean, Default value: false
 ;
@@ -312,10 +312,10 @@
 ; xdebug_connect_to_client(), or start on error or exception will not work. This provides
 ; almost 0% overhead for this case
 ;
-; If you need the just in time debugging capabilities, set this flag to true. In this case
+; If you need the on-demand debugging capabilities, set this flag to true. In this case
 ; the debugger will not be fully disabled if no connection is made at the start of the
 ; request and the overhead will be much larger. Only enable this option if you really require
-; these jit debugging capabilities
+; these on-demand debugging capabilities
 ;;
 ; .. note::
 ;
@@ -324,7 +324,7 @@
 ;    /docs/all_settings#XDEBUG_CONFIG
 ;
 ;
-;xdebug.jit_debugging_enabled = false
+;xdebug.on_demand_debugging_enabled = false
 
 ; -----------------------------------------------------------------------------
 ; xdebug.dump.*

--- a/xdebug.ini
+++ b/xdebug.ini
@@ -316,7 +316,7 @@
 ; the debugger will not be fully disabled if no connection is made at the start of the
 ; request and the overhead will be much larger. Only enable this option if you really require
 ; these on-demand debugging capabilities
-;;
+;
 ; .. note::
 ;
 ;    This setting can additionally be configured through the


### PR DESCRIPTION
This PR adds a new `jit_debugging_enabled` ini setting that allows you to disable some of the optimizations that we have added. When this is enabled you will be able to do JIT debugging even if you don't initially connect to any client by starting a connection using the `xdebug_connect_to_client` and `xdebug_break` functions or when an error or exception is raised. If you enable it then the performance gain is much smaller, instead of improving performance by 97% you will improve it by 60% (not bad in any case)

With this disabled I wanted to be able to disable even more operations so that we could save even more time but I found out that the only significant thing that we could add was not disabling the opcache optimizer, the other main source of overhead is the addition of the observer functions but this needs to be set up at the module initialization level, so we cannot actually disable it for each request depending on whether we connect or not

And the opcache optimizer is really only relevant for cgi/fpm processes, not cli processes, as opcache is not really useful for single use CLI commands and is usually disabled there, so I did not manage to really improve the current optimization by much

But what I was able to do is to get the vast majority of tests which had been marked as XFAIL to pass by setting this ini setting to enabled. There are still a couple which are still failing and where I need to take a deeper look. I also managed to get a few of the tests which had been skipped to pass by using this new setting or by changing some basic settings of the test setup