### PR TITLE
PIE packaging: update vendor name and add export-ignore

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,9 @@
+# Preserve line endings for symlink test
 /tests/debugger/bug00627-symlink.inc -text -filter
 /tests/develop/bug00744.phpt -text -filter
+
+# Exclude from release archives (git archive / PIE downloads)
+/tests/ export-ignore
+/.github/ export-ignore
+/.gitattributes export-ignore
+/.gitignore export-ignore

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,5 @@
 blank_issues_enabled: false
 contact_links:
   - name: Questions & Discussions
-    url: https://github.com/pronskiy/php-debugger/discussions
+    url: https://github.com/php-debugger/php-debugger/discussions
     about: Please ask questions or start discussions here instead of opening a bug report.

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Overall improvement: **97.1%**
 
 ### Manual download
 
-Grab the right binary from [Releases](https://github.com/pronskiy/php-debugger/releases), copy it to your extension directory, and add to `php.ini`:
+Grab the right binary from [Releases](https://github.com/php-debugger/php-debugger/releases), copy it to your extension directory, and add to `php.ini`:
 
 ```ini
 zend_extension=php_debugger.so
@@ -70,13 +70,13 @@ zend_extension=php_debugger.so
 **Quick install script:**
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/pronskiy/php-debugger/main/install.php | php
+curl -fsSL https://raw.githubusercontent.com/php-debugger/php-debugger/main/install.php | php
 ```
 
 **PIE (PHP Installer for Extensions):**
 
 ```bash
-pie install pronskiy/php-debugger
+pie install php-debugger/php-debugger
 ```
 
 ## Configuration

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "php-debugger/php-debugger",
     "type": "php-ext-zend",
     "license": "Xdebug-1.03",
-    "description": "A lightweight, high-performance PHP debugger. Drop-in Xdebug replacement focused on debugging.",
+    "description": "A lightweight, high-performance PHP debugger extension. Comptible with Xdebug step-debugging.",
     "homepage": "https://github.com/php-debugger/php-debugger",
     "authors": [
         {

--- a/composer.json
+++ b/composer.json
@@ -1,13 +1,18 @@
 {
-    "name": "pronskiy/php-debugger",
+    "name": "php-debugger/php-debugger",
     "type": "php-ext-zend",
     "license": "Xdebug-1.03",
     "description": "A lightweight, high-performance PHP debugger. Drop-in Xdebug replacement focused on debugging.",
-    "homepage": "https://github.com/pronskiy/php-debugger",
+    "homepage": "https://github.com/php-debugger/php-debugger",
     "authors": [
         {
             "name": "Roman Pronskiy",
             "role": "lead"
+        },
+        {
+            "name": "Carlos Granados",
+            "homepage": "https://github.com/carlos-granados",
+            "role": "maintainer"
         },
         {
             "name": "Derick Rethans",


### PR DESCRIPTION
## Changes

### Packagist vendor rename
- `pronskiy/php-debugger` → `php-debugger/php-debugger`
- Updated `composer.json` name, homepage
- Updated all references in README.md and issue templates

### `.gitattributes` export-ignore
Keeps release archives (used by PIE for source downloads) lean:
- `/tests/` — not needed for building
- `/.github/` — CI workflows not needed for building
- `/.gitattributes`, `/.gitignore`

### After merge
1. Tag `v0.1.0`
2. Submit `php-debugger/php-debugger` to Packagist
3. Users can install via: `pie install php-debugger/php-debugger`