### PR TITLE
Fix php_debugger.* INI aliases being silently ignored

### DIFF
--- a/tests/debugger/ini_alias_client_host.phpt
+++ b/tests/debugger/ini_alias_client_host.phpt
@@ -1,0 +1,33 @@
+--TEST--
+INI alias: php_debugger.* settings start a debug session
+--SKIPIF--
+<?php
+require __DIR__ . '/../utils.inc';
+check_reqs('dbgp');
+?>
+--FILE--
+<?php
+require 'dbgp/dbgpclient.php';
+
+// Use php_debugger.* prefix for mode and start_with_request
+// client_host/client_port come from xdebug.* defaults in dbgpRunFile
+dbgpRunFile(
+	dirname(__FILE__) . '/empty-echo.inc',
+	['step_into', 'detach'],
+	[
+		'php_debugger.mode' => 'debug',
+		'php_debugger.start_with_request' => "'yes'",
+	]
+);
+?>
+--EXPECTF--
+<?xml version="1.0" encoding="iso-8859-1"?>
+<init xmlns="urn:debugger_protocol_v1" xmlns:xdebug="https://xdebug.org/dbgp/xdebug" fileuri="file://empty-echo.inc" language="PHP" xdebug:language_version="" protocol_version="1.0" appid=""><engine version=""><![CDATA[PHP Debugger]]></engine><author><![CDATA[Derick Rethans]]></author><url><![CDATA[https://xdebug.org]]></url><copyright><![CDATA[Copyright (c) 2002-2099 by Derick Rethans]]></copyright></init>
+
+-> step_into -i 1
+<?xml version="1.0" encoding="iso-8859-1"?>
+<response xmlns="urn:debugger_protocol_v1" xmlns:xdebug="https://xdebug.org/dbgp/xdebug" command="step_into" transaction_id="1" status="break" reason="ok"><xdebug:message filename="file://empty-echo.inc" lineno="2"></xdebug:message></response>
+
+-> detach -i 2
+<?xml version="1.0" encoding="iso-8859-1"?>
+<response xmlns="urn:debugger_protocol_v1" xmlns:xdebug="https://xdebug.org/dbgp/xdebug" command="detach" transaction_id="2" status="stopping" reason="ok"></response>

--- a/tests/debugger/ini_alias_idekey.phpt
+++ b/tests/debugger/ini_alias_idekey.phpt
@@ -1,0 +1,24 @@
+--TEST--
+INI alias: php_debugger.idekey sets the IDE key in init packet
+--SKIPIF--
+<?php
+require __DIR__ . '/../utils.inc';
+check_reqs('dbgp');
+?>
+--FILE--
+<?php
+require 'dbgp/dbgpclient.php';
+
+dbgpRunFile(
+	dirname(__FILE__) . '/empty-echo.inc',
+	['detach'],
+	['php_debugger.mode' => 'debug', 'php_debugger.start_with_request' => 'yes', 'php_debugger.idekey' => 'MYIDEKEY']
+);
+?>
+--EXPECTF--
+<?xml version="1.0" encoding="iso-8859-1"?>
+<init xmlns="urn:debugger_protocol_v1" xmlns:xdebug="https://xdebug.org/dbgp/xdebug" fileuri="file://empty-echo.inc" language="PHP" xdebug:language_version="" protocol_version="1.0" appid="" idekey="MYIDEKEY"><engine version=""><![CDATA[PHP Debugger]]></engine><author><![CDATA[Derick Rethans]]></author><url><![CDATA[https://xdebug.org]]></url><copyright><![CDATA[Copyright (c) 2002-2099 by Derick Rethans]]></copyright></init>
+
+-> detach -i 1
+<?xml version="1.0" encoding="iso-8859-1"?>
+<response xmlns="urn:debugger_protocol_v1" xmlns:xdebug="https://xdebug.org/dbgp/xdebug" command="detach" transaction_id="1" status="stopping" reason="ok"></response>

--- a/tests/debugger/ini_alias_precedence.phpt
+++ b/tests/debugger/ini_alias_precedence.phpt
@@ -1,0 +1,29 @@
+--TEST--
+INI alias: php_debugger.* takes precedence when set before xdebug.*
+--SKIPIF--
+<?php
+require __DIR__ . '/../utils.inc';
+check_reqs('dbgp');
+?>
+--FILE--
+<?php
+require 'dbgp/dbgpclient.php';
+
+// php_debugger.idekey appears before xdebug.idekey in -d order.
+// php_debugger.* should still win (registration order, not CLI order).
+dbgpRunFile(
+	dirname(__FILE__) . '/empty-echo.inc',
+	['detach'],
+	[
+		'php_debugger.idekey' => 'debugger-key',
+		'xdebug.idekey' => 'xdebug-key',
+	]
+);
+?>
+--EXPECTF--
+<?xml version="1.0" encoding="iso-8859-1"?>
+<init xmlns="urn:debugger_protocol_v1" xmlns:xdebug="https://xdebug.org/dbgp/xdebug" fileuri="file://empty-echo.inc" language="PHP" xdebug:language_version="" protocol_version="1.0" appid="" idekey="debugger-key"><engine version=""><![CDATA[PHP Debugger]]></engine><author><![CDATA[Derick Rethans]]></author><url><![CDATA[https://xdebug.org]]></url><copyright><![CDATA[Copyright (c) 2002-2099 by Derick Rethans]]></copyright></init>
+
+-> detach -i 1
+<?xml version="1.0" encoding="iso-8859-1"?>
+<response xmlns="urn:debugger_protocol_v1" xmlns:xdebug="https://xdebug.org/dbgp/xdebug" command="detach" transaction_id="1" status="stopping" reason="ok"></response>

--- a/tests/debugger/ini_alias_precedence_ini_get.phpt
+++ b/tests/debugger/ini_alias_precedence_ini_get.phpt
@@ -1,0 +1,20 @@
+--TEST--
+INI alias: php_debugger.* takes precedence over xdebug.* regardless of order
+--INI--
+php_debugger.client_host=from-php-debugger
+xdebug.client_host=from-xdebug
+xdebug.idekey=xdebug-key
+php_debugger.idekey=debugger-key
+php_debugger.client_port=9002
+xdebug.client_port=9001
+--FILE--
+<?php
+// php_debugger.* should win in all cases, regardless of INI order
+var_dump(ini_get('xdebug.client_host'));
+var_dump(ini_get('xdebug.idekey'));
+var_dump(ini_get('xdebug.client_port'));
+?>
+--EXPECT--
+string(17) "from-php-debugger"
+string(12) "debugger-key"
+string(4) "9002"

--- a/tests/debugger/ini_alias_precedence_reverse.phpt
+++ b/tests/debugger/ini_alias_precedence_reverse.phpt
@@ -1,0 +1,29 @@
+--TEST--
+INI alias: php_debugger.* takes precedence when set after xdebug.*
+--SKIPIF--
+<?php
+require __DIR__ . '/../utils.inc';
+check_reqs('dbgp');
+?>
+--FILE--
+<?php
+require 'dbgp/dbgpclient.php';
+
+// xdebug.idekey appears before php_debugger.idekey in -d order.
+// php_debugger.* should still win (registration order, not CLI order).
+dbgpRunFile(
+	dirname(__FILE__) . '/empty-echo.inc',
+	['detach'],
+	[
+		'xdebug.idekey' => 'xdebug-key',
+		'php_debugger.idekey' => 'debugger-key',
+	]
+);
+?>
+--EXPECTF--
+<?xml version="1.0" encoding="iso-8859-1"?>
+<init xmlns="urn:debugger_protocol_v1" xmlns:xdebug="https://xdebug.org/dbgp/xdebug" fileuri="file://empty-echo.inc" language="PHP" xdebug:language_version="" protocol_version="1.0" appid="" idekey="debugger-key"><engine version=""><![CDATA[PHP Debugger]]></engine><author><![CDATA[Derick Rethans]]></author><url><![CDATA[https://xdebug.org]]></url><copyright><![CDATA[Copyright (c) 2002-2099 by Derick Rethans]]></copyright></init>
+
+-> detach -i 1
+<?xml version="1.0" encoding="iso-8859-1"?>
+<response xmlns="urn:debugger_protocol_v1" xmlns:xdebug="https://xdebug.org/dbgp/xdebug" command="detach" transaction_id="1" status="stopping" reason="ok"></response>

--- a/xdebug.c
+++ b/xdebug.c
@@ -222,60 +222,51 @@ ZEND_INI_DISP(display_start_upon_error)
 
 
 /*
- * Wrapper OnUpdate handlers for php_debugger.* INI aliases.
- *
- * These must not overwrite values set via the canonical xdebug.* entries
- * when the user has not explicitly set a php_debugger.* directive.
- *
- * During zend_register_ini_entries() (MINIT stage), entry->modified is
- * always 0, even when the user passed -dphp_debugger.foo=bar on the CLI.
- * We therefore check zend_get_configuration_directive() which returns
- * non-NULL when the value was explicitly set via php.ini, -d, or per-dir.
+ * php_debugger.* INI alias wrappers.
+ * Only apply when the user explicitly set the directive; skip defaults
+ * to avoid overwriting xdebug.* values. On success, sync the canonical
+ * xdebug.* entry so ini_get() reflects the effective value.
  */
 
 static inline bool php_debugger_ini_is_explicitly_set(zend_ini_entry *entry)
 {
-	/* After MINIT, entry->modified is reliable */
 	if (entry->modified) return true;
-	/* During MINIT, check whether the INI scanner saw this directive */
+	/* During MINIT entry->modified is always 0; fall back to config scanner */
 	return zend_get_configuration_directive(entry->name) != NULL;
 }
-static PHP_INI_MH(OnUpdatePhpDebuggerString)
-{
-	if (!php_debugger_ini_is_explicitly_set(entry)) return SUCCESS;
-	return OnUpdateString(entry, new_value, mh_arg1, mh_arg2, mh_arg3, stage);
-}
 
-static PHP_INI_MH(OnUpdatePhpDebuggerLong)
+static void php_debugger_sync_canonical(zend_ini_entry *alias_entry, zend_string *new_value)
 {
-	if (!php_debugger_ini_is_explicitly_set(entry)) return SUCCESS;
-	return OnUpdateLong(entry, new_value, mh_arg1, mh_arg2, mh_arg3, stage);
-}
+	const char *alias_name = ZSTR_VAL(alias_entry->name);
+	if (strncmp(alias_name, "php_debugger.", sizeof("php_debugger.") - 1) != 0) return;
 
-static PHP_INI_MH(OnUpdatePhpDebuggerBool)
-{
-	if (!php_debugger_ini_is_explicitly_set(entry)) return SUCCESS;
-	return OnUpdateBool(entry, new_value, mh_arg1, mh_arg2, mh_arg3, stage);
-}
+	char canonical[128];
+	snprintf(canonical, sizeof(canonical), "xdebug.%s", alias_name + sizeof("php_debugger.") - 1);
 
-static PHP_INI_MH(OnUpdatePhpDebuggerStartWithRequest)
-{
-	if (!php_debugger_ini_is_explicitly_set(entry)) return SUCCESS;
-	return OnUpdateStartWithRequest(entry, new_value, mh_arg1, mh_arg2, mh_arg3, stage);
-}
+	zend_string *key = zend_string_init(canonical, strlen(canonical), 0);
+	zend_ini_entry *canon = zend_hash_find_ptr(EG(ini_directives), key);
+	zend_string_release(key);
+	if (!canon) return;
 
-static PHP_INI_MH(OnUpdatePhpDebuggerStartUponError)
-{
-	if (!php_debugger_ini_is_explicitly_set(entry)) return SUCCESS;
-	return OnUpdateStartUponError(entry, new_value, mh_arg1, mh_arg2, mh_arg3, stage);
+	if (canon->value) zend_string_release(canon->value);
+	canon->value = zend_string_copy(new_value);
 }
+#define PHP_DEBUGGER_INI_WRAPPER(name, delegate) \
+	static PHP_INI_MH(name) { \
+		if (!php_debugger_ini_is_explicitly_set(entry)) return SUCCESS; \
+		int rc = delegate(entry, new_value, mh_arg1, mh_arg2, mh_arg3, stage); \
+		if (rc == SUCCESS) php_debugger_sync_canonical(entry, new_value); \
+		return rc; \
+	}
+
+PHP_DEBUGGER_INI_WRAPPER(OnUpdatePhpDebuggerString,           OnUpdateString)
+PHP_DEBUGGER_INI_WRAPPER(OnUpdatePhpDebuggerLong,             OnUpdateLong)
+PHP_DEBUGGER_INI_WRAPPER(OnUpdatePhpDebuggerBool,             OnUpdateBool)
+PHP_DEBUGGER_INI_WRAPPER(OnUpdatePhpDebuggerStartWithRequest, OnUpdateStartWithRequest)
+PHP_DEBUGGER_INI_WRAPPER(OnUpdatePhpDebuggerStartUponError,   OnUpdateStartUponError)
 
 #if HAVE_XDEBUG_CONTROL_SOCKET_SUPPORT
-static PHP_INI_MH(OnUpdatePhpDebuggerCtrlSocket)
-{
-	if (!php_debugger_ini_is_explicitly_set(entry)) return SUCCESS;
-	return OnUpdateCtrlSocket(entry, new_value, mh_arg1, mh_arg2, mh_arg3, stage);
-}
+PHP_DEBUGGER_INI_WRAPPER(OnUpdatePhpDebuggerCtrlSocket,       OnUpdateCtrlSocket)
 #endif
 
 PHP_INI_BEGIN()
@@ -317,9 +308,7 @@ PHP_INI_BEGIN()
 
 PHP_INI_END()
 
-/* INI aliases: php_debugger.* -> same storage as xdebug.*
- * Uses wrapper handlers that only apply when explicitly set by user,
- * preventing default values from overwriting xdebug.* settings. */
+/* php_debugger.* INI aliases — same storage as xdebug.* */
 static const zend_ini_entry_def php_debugger_ini_entries[] = {
 	/* Library settings */
 	STD_PHP_INI_ENTRY("php_debugger.mode",               "debug",               PHP_INI_SYSTEM,                OnUpdatePhpDebuggerString, settings.library.requested_mode,   zend_xdebug_globals, xdebug_globals)

--- a/xdebug.c
+++ b/xdebug.c
@@ -223,44 +223,57 @@ ZEND_INI_DISP(display_start_upon_error)
 
 /*
  * Wrapper OnUpdate handlers for php_debugger.* INI aliases.
- * These skip applying the default value (when entry->modified == 0),
- * so they don't overwrite values set via the canonical xdebug.* entries.
- * They only apply when the user explicitly sets php_debugger.* in php.ini.
+ *
+ * These must not overwrite values set via the canonical xdebug.* entries
+ * when the user has not explicitly set a php_debugger.* directive.
+ *
+ * During zend_register_ini_entries() (MINIT stage), entry->modified is
+ * always 0, even when the user passed -dphp_debugger.foo=bar on the CLI.
+ * We therefore check zend_get_configuration_directive() which returns
+ * non-NULL when the value was explicitly set via php.ini, -d, or per-dir.
  */
+
+static inline bool php_debugger_ini_is_explicitly_set(zend_ini_entry *entry)
+{
+	/* After MINIT, entry->modified is reliable */
+	if (entry->modified) return true;
+	/* During MINIT, check whether the INI scanner saw this directive */
+	return zend_get_configuration_directive(entry->name) != NULL;
+}
 static PHP_INI_MH(OnUpdatePhpDebuggerString)
 {
-	if (!entry->modified) return SUCCESS;
+	if (!php_debugger_ini_is_explicitly_set(entry)) return SUCCESS;
 	return OnUpdateString(entry, new_value, mh_arg1, mh_arg2, mh_arg3, stage);
 }
 
 static PHP_INI_MH(OnUpdatePhpDebuggerLong)
 {
-	if (!entry->modified) return SUCCESS;
+	if (!php_debugger_ini_is_explicitly_set(entry)) return SUCCESS;
 	return OnUpdateLong(entry, new_value, mh_arg1, mh_arg2, mh_arg3, stage);
 }
 
 static PHP_INI_MH(OnUpdatePhpDebuggerBool)
 {
-	if (!entry->modified) return SUCCESS;
+	if (!php_debugger_ini_is_explicitly_set(entry)) return SUCCESS;
 	return OnUpdateBool(entry, new_value, mh_arg1, mh_arg2, mh_arg3, stage);
 }
 
 static PHP_INI_MH(OnUpdatePhpDebuggerStartWithRequest)
 {
-	if (!entry->modified) return SUCCESS;
+	if (!php_debugger_ini_is_explicitly_set(entry)) return SUCCESS;
 	return OnUpdateStartWithRequest(entry, new_value, mh_arg1, mh_arg2, mh_arg3, stage);
 }
 
 static PHP_INI_MH(OnUpdatePhpDebuggerStartUponError)
 {
-	if (!entry->modified) return SUCCESS;
+	if (!php_debugger_ini_is_explicitly_set(entry)) return SUCCESS;
 	return OnUpdateStartUponError(entry, new_value, mh_arg1, mh_arg2, mh_arg3, stage);
 }
 
 #if HAVE_XDEBUG_CONTROL_SOCKET_SUPPORT
 static PHP_INI_MH(OnUpdatePhpDebuggerCtrlSocket)
 {
-	if (!entry->modified) return SUCCESS;
+	if (!php_debugger_ini_is_explicitly_set(entry)) return SUCCESS;
 	return OnUpdateCtrlSocket(entry, new_value, mh_arg1, mh_arg2, mh_arg3, stage);
 }
 #endif


### PR DESCRIPTION
## Problem

`php_debugger.*` INI aliases were silently ignored, and when both prefixes were set, `ini_get("xdebug.*")` did not reflect the `php_debugger.*` override.

Fixes #31

## Changes

**Fix alias detection during MINIT** — `entry->modified` is always 0 during `zend_register_ini_entries()`. Added `php_debugger_ini_is_explicitly_set()` which falls back to `zend_get_configuration_directive()` for MINIT-stage detection.

**Sync canonical entries** — When a `php_debugger.*` alias is set, `php_debugger_sync_canonical()` updates the corresponding `xdebug.*` entry value directly, so `ini_get("xdebug.foo")` reflects the effective value.

**`php_debugger.*` takes precedence** — When both prefixes are set, the `php_debugger.*` value wins regardless of directive order.

**Deduplicate wrappers** — All 6 identical `OnUpdatePhpDebugger*` handlers replaced with a `PHP_DEBUGGER_INI_WRAPPER` macro.

## Tests

- `ini_alias_client_host` — DBGp session using only `php_debugger.*` prefix
- `ini_alias_idekey` — `php_debugger.idekey` appears in DBGp init packet
- `ini_alias_precedence` — `php_debugger.*` wins when set before `xdebug.*`
- `ini_alias_precedence_reverse` — `php_debugger.*` wins when set after `xdebug.*`
- `ini_alias_precedence_ini_get` — `ini_get("xdebug.*")` returns `php_debugger.*` values (mixed order)