### PR TITLE
feat: Add DBGP emulator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -86,6 +86,7 @@ phpt.*
 !rector.php
 !generate_summary.php
 !tests/debugger/dbgp/dbgpclient.php
+!tests/debugger/dbgp/dbgp-emulator.php
 tests/ctest/*.o
 tests/ctest/afl-test-*
 tests/ctest/ctest

--- a/tests/debugger/dbgp/dbgp-emulator.php
+++ b/tests/debugger/dbgp/dbgp-emulator.php
@@ -1,6 +1,16 @@
 <?php
 require_once __DIR__ . '/dbgpclient.php';
 
+/**
+ * This can be used to emulate a DBGP client for debugging or benchmarking.
+ *
+ * Usage: php dbgp-emulator [--port=connection port] <command_list_file>
+ *
+ * When started it will wait to receive a connection from a php runner which
+ * has php-debugger enabled. Once connected, it will send to the debugger all the
+ * commands listed in the command list file. When the connection is terminated,
+ * it will exit and print the full exchange with the debugger
+ */
 class DbgpEmulator extends DebugClient
 {
 	protected $commands = [];
@@ -9,7 +19,6 @@ class DbgpEmulator extends DebugClient
 	public function __construct()
 	{
 		parent::__construct();
-		$this->setPort(9003);
 	}
 
 	public function loadCommands($filename)
@@ -132,15 +141,24 @@ if ($argc < 2) {
 }
 
 $commandFile = $argv[1];
+$port = 9003; // Default port
+
+// Parse command line options
+for ($i = 2; $i < $argc; $i++) {
+	if ($argv[$i] === '--port' && isset($argv[$i + 1])) {
+		$port = (int)$argv[$i + 1];
+		$i++; // Skip next argument since we've used it
+	}
+}
 
 $daemon = new DbgpEmulator();
+$daemon->setPort($port);
 
 if (!$daemon->loadCommands($commandFile)) {
 	exit(1);
 }
 
-echo "Starting DBGP emulator on port 9003...\n";
+echo "Starting DBGP emulator on port {$port}...\n";
 echo "Waiting for debugger connection...\n";
 
 $daemon->runEmulator();
-?>

--- a/tests/debugger/dbgp/dbgp-emulator.php
+++ b/tests/debugger/dbgp/dbgp-emulator.php
@@ -1,0 +1,146 @@
+<?php
+require_once __DIR__ . '/dbgpclient.php';
+
+class DbgpEmulator extends DebugClient
+{
+	protected $commands = [];
+	protected $conversation = [];
+
+	public function __construct()
+	{
+		parent::__construct();
+		$this->setPort(9003);
+	}
+
+	public function loadCommands($filename)
+	{
+		if (!file_exists($filename)) {
+			echo "Command file not found: {$filename}\n";
+			return false;
+		}
+
+		$content = file_get_contents($filename);
+		$this->commands = array_filter(
+			array_map('trim', explode("\n", $content)),
+			function($line) {
+				return !empty($line) && !str_starts_with($line, '#');
+			}
+		);
+
+		return true;
+	}
+
+	// Override doRead to capture conversation
+	function doRead($conn, ?string $transaction_id = null)
+	{
+		ob_start();
+		$result = parent::doRead($conn, $transaction_id);
+		$output = ob_get_clean();
+
+		if (!empty($output)) {
+			$this->conversation[] = "<- " . trim($output);
+		}
+
+		return $result;
+	}
+
+	// Override sendCommand to capture conversation
+	function sendCommand($conn, $command, $transaction_id)
+	{
+		ob_start();
+		parent::sendCommand($conn, $command, $transaction_id);
+		$output = ob_get_clean();
+
+		if (!empty($output)) {
+			$this->conversation[] = trim($output);
+		}
+	}
+
+	public function runEmulator()
+	{
+		// Open socket and wait for connection (but don't launch PHP)
+		$errno = null;
+		$errstr = null;
+		$this->socket = $this->open($errno, $errstr);
+
+		if ($this->socket === false) {
+			echo "Could not create socket server - already in use?\n";
+			echo "Error: {$errstr}, errno: {$errno}\n";
+			echo "Address: {$this->getAddress()}\n";
+			return false;
+		}
+
+		$conn = $this->acceptConnection(-1);
+
+		if ($conn === false) {
+			$this->conversation[] = "ERROR: Failed to accept connection";
+			fclose($this->socket);
+			return false;
+		}
+
+		$this->conversation[] = "Connection accepted!";
+
+		// Read init packet and extract PID
+		$this->doRead($conn);
+		$lastMessage = end($this->conversation);
+		if (preg_match('@appid="(\d+)"@', $lastMessage, $matches)) {
+			$this->pid = (int)$matches[1];
+		}
+
+		// Send commands
+		$i = 1;
+		foreach ($this->commands as $command) {
+			$this->sendCommand($conn, $command, $i);
+			$response = $this->doRead($conn, (string)$i);
+
+			// Check if the debugger has stopped
+			if ($response === null || feof($conn)) {
+				$this->conversation[] = "Connection closed by debugger";
+				break;
+			}
+
+			$i++;
+		}
+
+		// Clean up
+		$this->closeConnection($conn);
+
+		$this->printConversation();
+
+		return true;
+	}
+
+	function printConversation()
+	{
+		echo "\n";
+		echo "=== Full DBGP Conversation ===\n";
+		echo "==============================\n\n";
+		foreach ($this->conversation as $line) {
+			echo $line, "\n";
+		}
+		echo "\n==============================\n";
+	}
+}
+
+// Main execution
+if (php_sapi_name() !== 'cli') {
+	die("This script must be run from the command line\n");
+}
+
+if ($argc < 2) {
+	die("Error: Command file argument is required\n");
+}
+
+$commandFile = $argv[1];
+
+$daemon = new DbgpEmulator();
+
+if (!$daemon->loadCommands($commandFile)) {
+	exit(1);
+}
+
+echo "Starting DBGP emulator on port 9003...\n";
+echo "Waiting for debugger connection...\n";
+
+$daemon->runEmulator();
+?>

--- a/tests/debugger/dbgp/dbgpclient.php
+++ b/tests/debugger/dbgp/dbgpclient.php
@@ -35,7 +35,7 @@ class DebugClient
 	{
 	}
 
-	private function open( &$errno, &$errstr )
+	protected function open( &$errno, &$errstr )
 	{
 		$socket = @stream_socket_server( $this->getAddress(), $errno, $errstr );
 		if ( $socket )
@@ -45,6 +45,17 @@ class DebugClient
 			$this->port = array_pop( $name );
 		}
 		return $socket;
+	}
+
+	protected function acceptConnection( $timeout = 5 )
+	{
+		return @stream_socket_accept( $this->socket, $timeout );
+	}
+
+	protected function closeConnection( $conn )
+	{
+		fclose( $conn );
+		fclose( $this->socket );
 	}
 
 	private function launchPhp( &$pipes, $filename, array $ini_options = [], array $extra_options = [] )
@@ -190,7 +201,7 @@ class DebugClient
 			return false;
 		}
 		$this->php = $this->launchPhp( $this->ppipes, $filename, $ini_options, $options );
-		$conn = @stream_socket_accept( $this->socket, isset( $options['timeout'] ) ? $options['timeout'] : 5 );
+		$conn = $this->acceptConnection( isset( $options['timeout'] ) ? $options['timeout'] : 5 );
 
 		if ( $conn === false )
 		{
@@ -206,10 +217,9 @@ class DebugClient
 
 	function stop( $conn, array $options = [] )
 	{
-		fclose( $conn );
+		$this->closeConnection( $conn );
 		fclose( $this->ppipes[0] );
 		fclose( $this->ppipes[1] );
-		fclose( $this->socket );
 		proc_close( $this->php );
 
 		if ( array_key_exists( 'show-stdout', $options ) && $options['show-stdout'] )


### PR DESCRIPTION
Xdebug has the functionality needed to emulate a DBGP client defined in the DebugClient class but this was only used in tests.

In this PR we use this existing functionality to create a DBGP client emulator which can be run as a daemon, listening for incoming connections. It accepts an argument pointing to a file which contains a list of DBGP commands. When it accepts a connection, it will send these commands to the running php debugger and record the conversation.

This tool can be useful for two thing:
- Debugging the php debugger by emulating a connection with a client
- Testing the performance of the debugger when connection to a client