### PR TITLE
refactor: remove needs_debug_init flag

### DIFF
--- a/src/base/base.c
+++ b/src/base/base.c
@@ -714,7 +714,6 @@ static void xdebug_execute_user_code_begin(zend_execute_data *execute_data)
 		}
 
 		/* After first-call init, deactivate observer if no debugger connected */
-		XG_BASE(needs_debug_init) = 0;
 		if (!xdebug_is_debug_connection_active()) {
 			XG_BASE(observer_active) = 0;
 			return;
@@ -1273,7 +1272,6 @@ void xdebug_base_rinit()
 
 	/* Observer starts active to allow first-call debug init check */
 	XG_BASE(observer_active) = XDEBUG_MODE_IS(XDEBUG_MODE_STEP_DEBUG);
-	XG_BASE(needs_debug_init) = XDEBUG_MODE_IS(XDEBUG_MODE_STEP_DEBUG);
 
 	/* filters */
 	XG_BASE(filter_type_stack)         = XDEBUG_FILTER_NONE;

--- a/src/base/base_globals.h
+++ b/src/base/base_globals.h
@@ -60,7 +60,6 @@ typedef struct _xdebug_base_globals_t {
 	/* in-execution checking */
 	zend_bool  in_execution;
 	zend_bool  observer_active;     /* true when debug session is active or needs init */
-	zend_bool  needs_debug_init;    /* true until first-call debug init check is done */
 	zend_bool  in_var_serialisation;
 
 	/* Systemd Private Temp */


### PR DESCRIPTION
In phase 2 of the optimization the `needs_debug_init` flag was added, I guess to mark that the initial connection needed to be made. But this flag was not finally used anywhere and is unnecessary. This PR just removes it