### PR TITLE
feat: static build support (--enable-php-debugger)

### DIFF
--- a/.github/workflows/static-build.yml
+++ b/.github/workflows/static-build.yml
@@ -1,0 +1,105 @@
+name: "Static Build"
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'config.m4'
+      - 'php_php_debugger.h'
+      - 'xdebug.c'
+      - '.github/workflows/static-build.yml'
+  pull_request:
+    paths:
+      - 'config.m4'
+      - 'php_php_debugger.h'
+      - 'xdebug.c'
+      - '.github/workflows/static-build.yml'
+
+jobs:
+  static-build:
+    name: "Static — PHP ${{ matrix.php }}"
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        php: ['8.4']
+
+    steps:
+      - name: Checkout extension
+        uses: actions/checkout@v6
+        with:
+          path: ext-src
+
+      - name: Cache PHP source
+        uses: actions/cache@v4
+        id: php-cache
+        with:
+          path: ~/php-src
+          key: php-src-${{ matrix.php }}-${{ hashFiles('.github/workflows/static-build.yml') }}
+
+      - name: Clone PHP source
+        if: steps.php-cache.outputs.cache-hit != 'true'
+        run: |
+          git clone --depth=1 --branch="PHP-${{ matrix.php }}" \
+            https://github.com/php/php-src.git ~/php-src
+
+      - name: Install build dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y build-essential autoconf automake libtool re2c bison \
+            libxml2-dev libsqlite3-dev pkg-config
+
+      - name: Copy extension into php-src
+        run: |
+          cp -r ext-src ~/php-src/ext/php_debugger
+
+      - name: Build PHP with static php_debugger
+        run: |
+          cd ~/php-src
+          ./buildconf --force
+          ./configure \
+            --disable-all \
+            --enable-cli \
+            --enable-session \
+            --enable-php-debugger \
+            --without-pear
+          make -j$(nproc)
+
+      - name: Verify extension is statically linked
+        run: |
+          cd ~/php-src
+          # Extension must appear in module list
+          ./sapi/cli/php -m | grep -q php_debugger
+          # Xdebug compat alias must work
+          ./sapi/cli/php -m | grep -q xdebug
+          # Zend extension must be registered
+          ./sapi/cli/php -v | grep -q "PHP Debugger"
+
+      - name: Smoke test — extension_loaded
+        run: |
+          cd ~/php-src
+          ./sapi/cli/php -r "
+            assert(extension_loaded('php_debugger'), 'php_debugger not loaded');
+            assert(extension_loaded('xdebug'), 'xdebug compat alias not loaded');
+            echo 'extension_loaded: OK' . PHP_EOL;
+          "
+
+      - name: Smoke test — INI settings
+        run: |
+          cd ~/php-src
+          ./sapi/cli/php -r "
+            // Both INI prefixes must work
+            assert(ini_get('xdebug.client_port') !== false, 'xdebug.* INI missing');
+            assert(ini_get('php_debugger.client_port') !== false, 'php_debugger.* INI missing');
+            echo 'INI settings: OK' . PHP_EOL;
+          "
+
+      - name: Smoke test — functions
+        run: |
+          cd ~/php-src
+          ./sapi/cli/php -r "
+            assert(function_exists('xdebug_break'), 'xdebug_break missing');
+            assert(function_exists('php_debugger_break'), 'php_debugger_break missing');
+            assert(function_exists('xdebug_info'), 'xdebug_info missing');
+            echo 'Functions: OK' . PHP_EOL;
+          "

--- a/.github/workflows/static-build.yml
+++ b/.github/workflows/static-build.yml
@@ -89,7 +89,7 @@ jobs:
           cd ~/php-src
           ./sapi/cli/php -r "
             assert(function_exists('xdebug_break'), 'xdebug_break missing');
-            assert(function_exists('php_debugger_break'), 'php_debugger_break missing');
             assert(function_exists('xdebug_info'), 'xdebug_info missing');
+            assert(function_exists('php_debugger_info'), 'php_debugger_info missing');
             echo 'Functions: OK' . PHP_EOL;
           "

--- a/.github/workflows/static-build.yml
+++ b/.github/workflows/static-build.yml
@@ -44,6 +44,7 @@ jobs:
       - name: Copy extension into php-src
         run: |
           cp -r ext-src ~/php-src/ext/php_debugger
+          mkdir -p ~/php-src/m4
           cp ext-src/m4/*.m4 ~/php-src/m4/
 
       - name: Build PHP with static php_debugger

--- a/.github/workflows/static-build.yml
+++ b/.github/workflows/static-build.yml
@@ -52,6 +52,8 @@ jobs:
       - name: Copy extension into php-src
         run: |
           cp -r ext-src ~/php-src/ext/php_debugger
+          # m4 includes resolve relative to php-src root
+          cp ext-src/m4/*.m4 ~/php-src/m4/
 
       - name: Build PHP with static php_debugger
         run: |

--- a/.github/workflows/static-build.yml
+++ b/.github/workflows/static-build.yml
@@ -30,29 +30,20 @@ jobs:
         with:
           path: ext-src
 
-      - name: Cache PHP source
-        uses: actions/cache@v4
-        id: php-cache
-        with:
-          path: ~/php-src
-          key: php-src-${{ matrix.php }}-${{ hashFiles('.github/workflows/static-build.yml') }}
-
-      - name: Clone PHP source
-        if: steps.php-cache.outputs.cache-hit != 'true'
-        run: |
-          git clone --depth=1 --branch="PHP-${{ matrix.php }}" \
-            https://github.com/php/php-src.git ~/php-src
-
       - name: Install build dependencies
         run: |
           sudo apt-get update
           sudo apt-get install -y build-essential autoconf automake libtool re2c bison \
             libxml2-dev libsqlite3-dev pkg-config
 
+      - name: Clone PHP source
+        run: |
+          git clone --depth=1 --branch="PHP-${{ matrix.php }}" \
+            https://github.com/php/php-src.git ~/php-src
+
       - name: Copy extension into php-src
         run: |
           cp -r ext-src ~/php-src/ext/php_debugger
-          # m4 includes resolve relative to php-src root
           cp ext-src/m4/*.m4 ~/php-src/m4/
 
       - name: Build PHP with static php_debugger
@@ -70,11 +61,8 @@ jobs:
       - name: Verify extension is statically linked
         run: |
           cd ~/php-src
-          # Extension must appear in module list
           ./sapi/cli/php -m | grep -q php_debugger
-          # Xdebug compat alias must work
           ./sapi/cli/php -m | grep -q xdebug
-          # Zend extension must be registered
           ./sapi/cli/php -v | grep -q "PHP Debugger"
 
       - name: Smoke test — extension_loaded
@@ -90,7 +78,6 @@ jobs:
         run: |
           cd ~/php-src
           ./sapi/cli/php -r "
-            // Both INI prefixes must work
             assert(ini_get('xdebug.client_port') !== false, 'xdebug.* INI missing');
             assert(ini_get('php_debugger.client_port') !== false, 'php_debugger.* INI missing');
             echo 'INI settings: OK' . PHP_EOL;

--- a/config.m4
+++ b/config.m4
@@ -116,4 +116,5 @@ if test "$PHP_PHP_DEBUGGER" != "no"; then
 
   PHP_ADD_INCLUDE($ext_srcdir/src)
   PHP_ADD_INCLUDE($ext_builddir/src)
+  PHP_ADD_INCLUDE($ext_srcdir)
 fi

--- a/php_php_debugger.h
+++ b/php_php_debugger.h
@@ -1,0 +1,14 @@
+/*
+ * Bridge header for PHP's static build system.
+ * Provides phpext_php_debugger_ptr for main/internal_functions.c.
+ */
+
+#ifndef PHP_PHP_DEBUGGER_H
+#define PHP_PHP_DEBUGGER_H
+
+#include "php_xdebug.h"
+
+extern zend_module_entry xdebug_module_entry;
+#define phpext_php_debugger_ptr &xdebug_module_entry
+
+#endif /* PHP_PHP_DEBUGGER_H */

--- a/php_xdebug.stub.php
+++ b/php_xdebug.stub.php
@@ -18,6 +18,13 @@ function xdebug_connect_to_client(): bool {}
 /** @return mixed */
 function xdebug_info(?string $category = null) {}
 
+/* Alias of xdebug_info() in the php_debugger namespace */
+/**
+ * @alias xdebug_info
+ * @return mixed
+ */
+function php_debugger_info(?string $category = null) {}
+
 /* -----------------------------------------------------------------------*/
 
 /* Returns whether a debugging session is active */

--- a/php_xdebug_arginfo.h
+++ b/php_xdebug_arginfo.h
@@ -164,6 +164,7 @@ static const zend_function_entry ext_functions[] = {
 	ZEND_FE(xdebug_break, arginfo_xdebug_break)
 	ZEND_FE(xdebug_connect_to_client, arginfo_xdebug_connect_to_client)
 	ZEND_FE(xdebug_info, arginfo_xdebug_info)
+	ZEND_FALIAS(php_debugger_info, xdebug_info, arginfo_xdebug_info)
 	ZEND_FE(xdebug_is_debugger_active, arginfo_xdebug_is_debugger_active)
 	ZEND_FE(xdebug_notify, arginfo_xdebug_notify)
 	ZEND_FE(xdebug_get_profiler_filename, arginfo_xdebug_get_profiler_filename)

--- a/xdebug.c
+++ b/xdebug.c
@@ -70,6 +70,9 @@ int xdebug_include_or_eval_handler(zend_execute_data *execute_data);
 /* True globals */
 int zend_xdebug_initialised = 0;
 int xdebug_global_mode = 0;
+/* Forward declaration for static build self-registration */
+extern ZEND_DLEXPORT zend_extension zend_extension_entry;
+
 
 zend_module_entry xdebug_module_entry = {
 	STANDARD_MODULE_HEADER,
@@ -473,6 +476,28 @@ int xdebug_is_output_tty(void)
 PHP_MINIT_FUNCTION(xdebug)
 {
 	zend_string *alias_name;
+
+#ifndef COMPILE_DL_PHP_DEBUGGER
+	/* Static build: register ourselves as a Zend extension from MINIT.
+	 * In shared builds, this is handled by the zend_extension= INI directive
+	 * and xdebug_zend_startup runs during zend_startup_extensions.
+	 * In static builds, the PHP module is auto-registered but the Zend extension
+	 * is not, and zend_startup_extensions has already run by the time MINIT fires.
+	 * So we register the Zend extension and manually perform its startup steps. */
+	{
+		zend_extension *existing = zend_get_extension(XDEBUG_NAME);
+		if (!existing) {
+			zend_register_extension(&zend_extension_entry, NULL);
+			/* Replicate xdebug_zend_startup() logic, minus zend_startup_module()
+			 * which would double-register the already-active PHP module. */
+			xdebug_library_zend_startup();
+			xdebug_debugger_zend_startup();
+			zend_xdebug_initialised = 1;
+			xdebug_orig_post_startup_cb = zend_post_startup_cb;
+			zend_post_startup_cb = xdebug_post_startup;
+		}
+	}
+#endif
 	ZEND_INIT_MODULE_GLOBALS(xdebug, php_xdebug_init_globals, php_xdebug_shutdown_globals);
 	REGISTER_INI_ENTRIES();
 
@@ -559,7 +584,7 @@ PHP_RINIT_FUNCTION(xdebug)
 	int debug_requested;
 	int connected;
 
-#if defined(ZTS) && defined(COMPILE_DL_XDEBUG)
+#if defined(ZTS) && defined(COMPILE_DL_PHP_DEBUGGER)
 	ZEND_TSRMLS_CACHE_UPDATE();
 #endif
 
@@ -695,6 +720,13 @@ ZEND_DLEXPORT void xdebug_statement_call(zend_execute_data *frame)
 
 ZEND_DLEXPORT int xdebug_zend_startup(zend_extension *extension)
 {
+
+#ifndef COMPILE_DL_PHP_DEBUGGER
+	/* Static build: module already registered and initialized via static ext table + MINIT.
+	 * xdebug_zend_startup is called again by zend_startup_extensions(), but all
+	 * work was already done in MINIT. Skip to avoid double module registration. */
+	return SUCCESS;
+#endif
 	xdebug_library_zend_startup();
 	xdebug_debugger_zend_startup();
 


### PR DESCRIPTION
Adds support for compiling php_debugger as a static extension into php-src, producing a single binary with the debugger built in — no .so required.

Fixes #40 

## Usage

### In-tree (php-src)

```bash
# Symlink or copy into php-src/ext/
ln -s /path/to/php-debugger ext/php_debugger

# Build
./buildconf --force
./configure --enable-php-debugger [other flags...]
make -j$(nproc)

# Verify
./sapi/cli/php -m | grep php_debugger
```

### static-php-cli

Also verified with [static-php-cli](https://github.com/crazywhalecc/static-php-cli) — produces a fully static, zero-dependency binary:

```
$ file php
ELF 64-bit LSB executable, x86-64, statically linked, stripped

$ ls -lh php
4.6M

$ ./php -v
PHP 8.4.20 (cli) (NTS x86_64-linux-musl-gcc)
Built by static-php-cli 2.8.5
Zend Engine v4.4.20
    with PHP Debugger v0.1.0-dev

$ ./php -r "var_dump(extension_loaded('php_debugger'), extension_loaded('xdebug'));"
bool(true)
bool(true)
```

static-php-cli recipe will be submitted as a separate PR.

## Changes

- **MINIT self-registration** — In static builds, `zend_startup_extensions()` has already run by MINIT time, so we register the Zend extension manually from `PHP_MINIT_FUNCTION` and call the startup functions inline
- **`xdebug_zend_startup()` guard** — Early return in static builds to prevent double module registration when `zend_startup_extensions()` calls it after MINIT
- **`php_php_debugger.h`** — Bridge header providing `phpext_php_debugger_ptr` for PHP's static extension table (`main/internal_functions.c`)
- **`config.m4`** — Add `PHP_ADD_INCLUDE` for header discovery
- **ZTS fix** — `COMPILE_DL_XDEBUG` → `COMPILE_DL_PHP_DEBUGGER` in RINIT
- **CI** — Dedicated `static-build.yml` workflow: builds PHP from source with `--enable-php-debugger`, runs smoke tests. Only triggers on changes to static-build-related files.

## Benchmark (PHP 8.6.0-dev, bench.php, Linux x86_64)

| Config | Time | Overhead |
|---|---|---|
| Vanilla PHP (no ext) | 0.573s | baseline |
| Static php_debugger (loaded, no client) | 0.605s | ~5.6% |

Same observer API floor as the shared build.

## Compatibility

- `extension_loaded("php_debugger")` ✅
- `extension_loaded("xdebug")` ✅ (compat alias)
- All `php_debugger.*` and `xdebug.*` INI settings work
- Shared builds (`zend_extension=php_debugger.so`) unaffected
- Verified with static-php-cli (musl, fully static, 4.6 MB)