### PR TITLE
feat: compatibility stubs for stripped Xdebug functions

### DIFF
--- a/config.m4
+++ b/config.m4
@@ -99,7 +99,7 @@ if test "$PHP_PHP_DEBUGGER" != "no"; then
   PHP_XDEBUG_CFLAGS="$STD_CFLAGS $MAINTAINER_CFLAGS"
 
   XDEBUG_BASE_SOURCES="src/base/base.c src/base/ctrl_socket.c src/base/filter.c"
-  XDEBUG_LIB_SOURCES="src/lib/usefulstuff.c src/lib/cmd_parser.c src/lib/compat.c src/lib/crc32.c src/lib/file.c src/lib/hash.c src/lib/headers.c src/lib/lib.c src/lib/llist.c src/lib/log.c src/lib/normalize_path.c src/lib/set.c src/lib/str.c src/lib/timing.c src/lib/trim.c src/lib/var.c src/lib/var_export_html.c src/lib/var_export_line.c src/lib/var_export_text.c src/lib/var_export_xml.c src/lib/xdebug_strndup.c src/lib/xml.c"
+  XDEBUG_LIB_SOURCES="src/lib/usefulstuff.c src/lib/cmd_parser.c src/lib/compat.c src/lib/crc32.c src/lib/file.c src/lib/hash.c src/lib/headers.c src/lib/lib.c src/lib/llist.c src/lib/log.c src/lib/normalize_path.c src/lib/set.c src/lib/str.c src/lib/timing.c src/lib/trim.c src/lib/var.c src/lib/var_export_html.c src/lib/var_export_line.c src/lib/var_export_text.c src/lib/var_export_xml.c src/lib/xdebug_strndup.c src/lib/xml.c src/lib/compat_stubs.c"
   XDEBUG_LIB_MAPS_SOURCES="src/lib/maps/maps.c src/lib/maps/maps_private.c src/lib/maps/parser.c"
 
   XDEBUG_DEBUGGER_SOURCES="src/debugger/com.c src/debugger/debugger.c src/debugger/handler_dbgp.c src/debugger/handlers.c src/debugger/ip_info.c"

--- a/config.w32
+++ b/config.w32
@@ -4,7 +4,7 @@ ARG_ENABLE("debugger", "PHP Debugger support", "no");
 
 if (PHP_DEBUGGER == 'yes') {
 	var XDEBUG_BASE_SOURCES="base.c filter.c ctrl_socket.c"
-	var XDEBUG_LIB_SOURCES="usefulstuff.c cmd_parser.c compat.c crc32.c file.c hash.c headers.c lib.c llist.c log.c normalize_path.c set.c str.c timing.c trim.c var.c var_export_html.c var_export_line.c var_export_text.c var_export_xml.c xdebug_strndup.c xml.c"
+	var XDEBUG_LIB_SOURCES="usefulstuff.c cmd_parser.c compat.c crc32.c file.c hash.c headers.c lib.c llist.c log.c normalize_path.c set.c str.c timing.c trim.c var.c var_export_html.c var_export_line.c var_export_text.c var_export_xml.c xdebug_strndup.c xml.c compat_stubs.c"
 	var XDEBUG_LIB_MAPS_SOURCES="maps.c maps_private.c parser.c"
 	var XDEBUG_DEBUGGER_SOURCES="com.c debugger.c handler_dbgp.c handlers.c ip_info.c"
 

--- a/php_xdebug.stub.php
+++ b/php_xdebug.stub.php
@@ -100,7 +100,6 @@ function xdebug_get_collected_errors(bool $emptyList = false): array {}
 
 function xdebug_get_function_stack(array $options = []): array {}
 
-function xdebug_get_headers(): array {}
 
 function xdebug_get_stack_depth(): int {}
 

--- a/php_xdebug.stub.php
+++ b/php_xdebug.stub.php
@@ -100,7 +100,6 @@ function xdebug_get_collected_errors(bool $emptyList = false): array {}
 
 function xdebug_get_function_stack(array $options = []): array {}
 
-
 function xdebug_get_stack_depth(): int {}
 
 function xdebug_memory_usage(): int {}

--- a/php_xdebug.stub.php
+++ b/php_xdebug.stub.php
@@ -29,3 +29,91 @@ function xdebug_is_debugger_active(): bool {}
 function xdebug_notify(mixed $data): bool {}
 
 /* -----------------------------------------------------------------------*/
+/* Compatibility stubs — profiler                                         */
+/* -----------------------------------------------------------------------*/
+
+function xdebug_get_profiler_filename(): string|false {}
+
+/* -----------------------------------------------------------------------*/
+/* Compatibility stubs — coverage                                         */
+/* -----------------------------------------------------------------------*/
+
+function xdebug_code_coverage_started(): bool {}
+
+function xdebug_get_code_coverage(): array {}
+
+function xdebug_start_code_coverage(int $options = 0): void {}
+
+function xdebug_stop_code_coverage(bool $cleanUp = true): void {}
+
+/* -----------------------------------------------------------------------*/
+/* Compatibility stubs — tracing                                          */
+/* -----------------------------------------------------------------------*/
+
+function xdebug_get_tracefile_name(): string|false {}
+
+function xdebug_start_trace(?string $traceFile = null, int $options = 0): string|false {}
+
+function xdebug_stop_trace(): string|false {}
+
+function xdebug_get_function_count(): int {}
+
+function xdebug_start_function_monitor(array $functionNames): void {}
+
+function xdebug_stop_function_monitor(): void {}
+
+function xdebug_get_monitored_functions(): array {}
+
+/* -----------------------------------------------------------------------*/
+/* Compatibility stubs — gcstats                                          */
+/* -----------------------------------------------------------------------*/
+
+function xdebug_get_gc_run_count(): int {}
+
+function xdebug_get_gc_total_collected_roots(): int {}
+
+function xdebug_get_gcstats_filename(): string|false {}
+
+function xdebug_start_gcstats(): string|false {}
+
+function xdebug_stop_gcstats(): string|false {}
+
+/* -----------------------------------------------------------------------*/
+/* Compatibility stubs — develop                                          */
+/* -----------------------------------------------------------------------*/
+
+function xdebug_call_class(int $depth = 2): string|false {}
+
+function xdebug_call_file(int $depth = 2): string|false {}
+
+function xdebug_call_function(int $depth = 2): string|false {}
+
+function xdebug_call_line(int $depth = 2): int {}
+
+function xdebug_debug_zval(string ...$varName): void {}
+
+function xdebug_debug_zval_stdout(string ...$varName): void {}
+
+function xdebug_dump_superglobals(): void {}
+
+function xdebug_get_collected_errors(bool $emptyList = false): array {}
+
+function xdebug_get_function_stack(array $options = []): array {}
+
+function xdebug_get_headers(): array {}
+
+function xdebug_get_stack_depth(): int {}
+
+function xdebug_memory_usage(): int {}
+
+function xdebug_peak_memory_usage(): int {}
+
+function xdebug_print_function_stack(string $message = 'user triggered', int $options = 0): void {}
+
+function xdebug_start_error_collection(): void {}
+
+function xdebug_stop_error_collection(): void {}
+
+function xdebug_time_index(): float {}
+
+function xdebug_var_dump(mixed ...$var): void {}

--- a/php_xdebug_arginfo.h
+++ b/php_xdebug_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit php_xdebug.stub.php instead.
- * Stub hash: edd68183eb73251289cbc16760372598e42fb968 */
+ * Stub hash: 16bb1cdc731ec0b8166a7d05632d0b63480d60e1 */
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_xdebug_break, 0, 0, _IS_BOOL, 0)
 ZEND_END_ARG_INFO()
@@ -16,11 +16,145 @@ ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_xdebug_notify, 0, 1, _IS_BOOL, 0
 	ZEND_ARG_TYPE_INFO(0, data, IS_MIXED, 0)
 ZEND_END_ARG_INFO()
 
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_xdebug_get_profiler_filename, 0, 0, MAY_BE_STRING|MAY_BE_FALSE)
+ZEND_END_ARG_INFO()
+
+#define arginfo_xdebug_code_coverage_started arginfo_xdebug_break
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_xdebug_get_code_coverage, 0, 0, IS_ARRAY, 0)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_xdebug_start_code_coverage, 0, 0, IS_VOID, 0)
+	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, options, IS_LONG, 0, "0")
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_xdebug_stop_code_coverage, 0, 0, IS_VOID, 0)
+	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, cleanUp, _IS_BOOL, 0, "true")
+ZEND_END_ARG_INFO()
+
+#define arginfo_xdebug_get_tracefile_name arginfo_xdebug_get_profiler_filename
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_xdebug_start_trace, 0, 0, MAY_BE_STRING|MAY_BE_FALSE)
+	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, traceFile, IS_STRING, 1, "null")
+	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, options, IS_LONG, 0, "0")
+ZEND_END_ARG_INFO()
+
+#define arginfo_xdebug_stop_trace arginfo_xdebug_get_profiler_filename
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_xdebug_get_function_count, 0, 0, IS_LONG, 0)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_xdebug_start_function_monitor, 0, 1, IS_VOID, 0)
+	ZEND_ARG_TYPE_INFO(0, functionNames, IS_ARRAY, 0)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_xdebug_stop_function_monitor, 0, 0, IS_VOID, 0)
+ZEND_END_ARG_INFO()
+
+#define arginfo_xdebug_get_monitored_functions arginfo_xdebug_get_code_coverage
+
+#define arginfo_xdebug_get_gc_run_count arginfo_xdebug_get_function_count
+
+#define arginfo_xdebug_get_gc_total_collected_roots arginfo_xdebug_get_function_count
+
+#define arginfo_xdebug_get_gcstats_filename arginfo_xdebug_get_profiler_filename
+
+#define arginfo_xdebug_start_gcstats arginfo_xdebug_get_profiler_filename
+
+#define arginfo_xdebug_stop_gcstats arginfo_xdebug_get_profiler_filename
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_xdebug_call_class, 0, 0, MAY_BE_STRING|MAY_BE_FALSE)
+	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, depth, IS_LONG, 0, "2")
+ZEND_END_ARG_INFO()
+
+#define arginfo_xdebug_call_file arginfo_xdebug_call_class
+
+#define arginfo_xdebug_call_function arginfo_xdebug_call_class
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_xdebug_call_line, 0, 0, IS_LONG, 0)
+	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, depth, IS_LONG, 0, "2")
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_xdebug_debug_zval, 0, 0, IS_VOID, 0)
+	ZEND_ARG_VARIADIC_TYPE_INFO(0, varName, IS_STRING, 0)
+ZEND_END_ARG_INFO()
+
+#define arginfo_xdebug_debug_zval_stdout arginfo_xdebug_debug_zval
+
+#define arginfo_xdebug_dump_superglobals arginfo_xdebug_stop_function_monitor
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_xdebug_get_collected_errors, 0, 0, IS_ARRAY, 0)
+	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, emptyList, _IS_BOOL, 0, "false")
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_xdebug_get_function_stack, 0, 0, IS_ARRAY, 0)
+	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, options, IS_ARRAY, 0, "[]")
+ZEND_END_ARG_INFO()
+
+#define arginfo_xdebug_get_headers arginfo_xdebug_get_code_coverage
+
+#define arginfo_xdebug_get_stack_depth arginfo_xdebug_get_function_count
+
+#define arginfo_xdebug_memory_usage arginfo_xdebug_get_function_count
+
+#define arginfo_xdebug_peak_memory_usage arginfo_xdebug_get_function_count
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_xdebug_print_function_stack, 0, 0, IS_VOID, 0)
+	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, message, IS_STRING, 0, "\'user triggered\'")
+	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, options, IS_LONG, 0, "0")
+ZEND_END_ARG_INFO()
+
+#define arginfo_xdebug_start_error_collection arginfo_xdebug_stop_function_monitor
+
+#define arginfo_xdebug_stop_error_collection arginfo_xdebug_stop_function_monitor
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_xdebug_time_index, 0, 0, IS_DOUBLE, 0)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_xdebug_var_dump, 0, 0, IS_VOID, 0)
+	ZEND_ARG_VARIADIC_TYPE_INFO(0, var, IS_MIXED, 0)
+ZEND_END_ARG_INFO()
+
 ZEND_FUNCTION(xdebug_break);
 ZEND_FUNCTION(xdebug_connect_to_client);
 ZEND_FUNCTION(xdebug_info);
 ZEND_FUNCTION(xdebug_is_debugger_active);
 ZEND_FUNCTION(xdebug_notify);
+ZEND_FUNCTION(xdebug_get_profiler_filename);
+ZEND_FUNCTION(xdebug_code_coverage_started);
+ZEND_FUNCTION(xdebug_get_code_coverage);
+ZEND_FUNCTION(xdebug_start_code_coverage);
+ZEND_FUNCTION(xdebug_stop_code_coverage);
+ZEND_FUNCTION(xdebug_get_tracefile_name);
+ZEND_FUNCTION(xdebug_start_trace);
+ZEND_FUNCTION(xdebug_stop_trace);
+ZEND_FUNCTION(xdebug_get_function_count);
+ZEND_FUNCTION(xdebug_start_function_monitor);
+ZEND_FUNCTION(xdebug_stop_function_monitor);
+ZEND_FUNCTION(xdebug_get_monitored_functions);
+ZEND_FUNCTION(xdebug_get_gc_run_count);
+ZEND_FUNCTION(xdebug_get_gc_total_collected_roots);
+ZEND_FUNCTION(xdebug_get_gcstats_filename);
+ZEND_FUNCTION(xdebug_start_gcstats);
+ZEND_FUNCTION(xdebug_stop_gcstats);
+ZEND_FUNCTION(xdebug_call_class);
+ZEND_FUNCTION(xdebug_call_file);
+ZEND_FUNCTION(xdebug_call_function);
+ZEND_FUNCTION(xdebug_call_line);
+ZEND_FUNCTION(xdebug_debug_zval);
+ZEND_FUNCTION(xdebug_debug_zval_stdout);
+ZEND_FUNCTION(xdebug_dump_superglobals);
+ZEND_FUNCTION(xdebug_get_collected_errors);
+ZEND_FUNCTION(xdebug_get_function_stack);
+ZEND_FUNCTION(xdebug_get_headers);
+ZEND_FUNCTION(xdebug_get_stack_depth);
+ZEND_FUNCTION(xdebug_memory_usage);
+ZEND_FUNCTION(xdebug_peak_memory_usage);
+ZEND_FUNCTION(xdebug_print_function_stack);
+ZEND_FUNCTION(xdebug_start_error_collection);
+ZEND_FUNCTION(xdebug_stop_error_collection);
+ZEND_FUNCTION(xdebug_time_index);
+ZEND_FUNCTION(xdebug_var_dump);
 
 static const zend_function_entry ext_functions[] = {
 	ZEND_FE(xdebug_break, arginfo_xdebug_break)
@@ -28,6 +162,41 @@ static const zend_function_entry ext_functions[] = {
 	ZEND_FE(xdebug_info, arginfo_xdebug_info)
 	ZEND_FE(xdebug_is_debugger_active, arginfo_xdebug_is_debugger_active)
 	ZEND_FE(xdebug_notify, arginfo_xdebug_notify)
+	ZEND_FE(xdebug_get_profiler_filename, arginfo_xdebug_get_profiler_filename)
+	ZEND_FE(xdebug_code_coverage_started, arginfo_xdebug_code_coverage_started)
+	ZEND_FE(xdebug_get_code_coverage, arginfo_xdebug_get_code_coverage)
+	ZEND_FE(xdebug_start_code_coverage, arginfo_xdebug_start_code_coverage)
+	ZEND_FE(xdebug_stop_code_coverage, arginfo_xdebug_stop_code_coverage)
+	ZEND_FE(xdebug_get_tracefile_name, arginfo_xdebug_get_tracefile_name)
+	ZEND_FE(xdebug_start_trace, arginfo_xdebug_start_trace)
+	ZEND_FE(xdebug_stop_trace, arginfo_xdebug_stop_trace)
+	ZEND_FE(xdebug_get_function_count, arginfo_xdebug_get_function_count)
+	ZEND_FE(xdebug_start_function_monitor, arginfo_xdebug_start_function_monitor)
+	ZEND_FE(xdebug_stop_function_monitor, arginfo_xdebug_stop_function_monitor)
+	ZEND_FE(xdebug_get_monitored_functions, arginfo_xdebug_get_monitored_functions)
+	ZEND_FE(xdebug_get_gc_run_count, arginfo_xdebug_get_gc_run_count)
+	ZEND_FE(xdebug_get_gc_total_collected_roots, arginfo_xdebug_get_gc_total_collected_roots)
+	ZEND_FE(xdebug_get_gcstats_filename, arginfo_xdebug_get_gcstats_filename)
+	ZEND_FE(xdebug_start_gcstats, arginfo_xdebug_start_gcstats)
+	ZEND_FE(xdebug_stop_gcstats, arginfo_xdebug_stop_gcstats)
+	ZEND_FE(xdebug_call_class, arginfo_xdebug_call_class)
+	ZEND_FE(xdebug_call_file, arginfo_xdebug_call_file)
+	ZEND_FE(xdebug_call_function, arginfo_xdebug_call_function)
+	ZEND_FE(xdebug_call_line, arginfo_xdebug_call_line)
+	ZEND_FE(xdebug_debug_zval, arginfo_xdebug_debug_zval)
+	ZEND_FE(xdebug_debug_zval_stdout, arginfo_xdebug_debug_zval_stdout)
+	ZEND_FE(xdebug_dump_superglobals, arginfo_xdebug_dump_superglobals)
+	ZEND_FE(xdebug_get_collected_errors, arginfo_xdebug_get_collected_errors)
+	ZEND_FE(xdebug_get_function_stack, arginfo_xdebug_get_function_stack)
+	ZEND_FE(xdebug_get_headers, arginfo_xdebug_get_headers)
+	ZEND_FE(xdebug_get_stack_depth, arginfo_xdebug_get_stack_depth)
+	ZEND_FE(xdebug_memory_usage, arginfo_xdebug_memory_usage)
+	ZEND_FE(xdebug_peak_memory_usage, arginfo_xdebug_peak_memory_usage)
+	ZEND_FE(xdebug_print_function_stack, arginfo_xdebug_print_function_stack)
+	ZEND_FE(xdebug_start_error_collection, arginfo_xdebug_start_error_collection)
+	ZEND_FE(xdebug_stop_error_collection, arginfo_xdebug_stop_error_collection)
+	ZEND_FE(xdebug_time_index, arginfo_xdebug_time_index)
+	ZEND_FE(xdebug_var_dump, arginfo_xdebug_var_dump)
 	/* php_debugger_* aliases */
 	ZEND_FALIAS(php_debugger_break, xdebug_break, arginfo_xdebug_break)
 	ZEND_FALIAS(php_debugger_connect_to_client, xdebug_connect_to_client, arginfo_xdebug_connect_to_client)

--- a/php_xdebug_arginfo.h
+++ b/php_xdebug_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit php_xdebug.stub.php instead.
- * Stub hash: 16bb1cdc731ec0b8166a7d05632d0b63480d60e1 */
+ * Stub hash: 90054ce38776046c4312c1dba4833dce6b8ac1f6 */
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_xdebug_break, 0, 0, _IS_BOOL, 0)
 ZEND_END_ARG_INFO()
@@ -91,8 +91,6 @@ ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_xdebug_get_function_stack, 0, 0,
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, options, IS_ARRAY, 0, "[]")
 ZEND_END_ARG_INFO()
 
-#define arginfo_xdebug_get_headers arginfo_xdebug_get_code_coverage
-
 #define arginfo_xdebug_get_stack_depth arginfo_xdebug_get_function_count
 
 #define arginfo_xdebug_memory_usage arginfo_xdebug_get_function_count
@@ -146,7 +144,6 @@ ZEND_FUNCTION(xdebug_debug_zval_stdout);
 ZEND_FUNCTION(xdebug_dump_superglobals);
 ZEND_FUNCTION(xdebug_get_collected_errors);
 ZEND_FUNCTION(xdebug_get_function_stack);
-ZEND_FUNCTION(xdebug_get_headers);
 ZEND_FUNCTION(xdebug_get_stack_depth);
 ZEND_FUNCTION(xdebug_memory_usage);
 ZEND_FUNCTION(xdebug_peak_memory_usage);
@@ -188,7 +185,6 @@ static const zend_function_entry ext_functions[] = {
 	ZEND_FE(xdebug_dump_superglobals, arginfo_xdebug_dump_superglobals)
 	ZEND_FE(xdebug_get_collected_errors, arginfo_xdebug_get_collected_errors)
 	ZEND_FE(xdebug_get_function_stack, arginfo_xdebug_get_function_stack)
-	ZEND_FE(xdebug_get_headers, arginfo_xdebug_get_headers)
 	ZEND_FE(xdebug_get_stack_depth, arginfo_xdebug_get_stack_depth)
 	ZEND_FE(xdebug_memory_usage, arginfo_xdebug_memory_usage)
 	ZEND_FE(xdebug_peak_memory_usage, arginfo_xdebug_peak_memory_usage)
@@ -197,11 +193,5 @@ static const zend_function_entry ext_functions[] = {
 	ZEND_FE(xdebug_stop_error_collection, arginfo_xdebug_stop_error_collection)
 	ZEND_FE(xdebug_time_index, arginfo_xdebug_time_index)
 	ZEND_FE(xdebug_var_dump, arginfo_xdebug_var_dump)
-	/* php_debugger_* aliases */
-	ZEND_FALIAS(php_debugger_break, xdebug_break, arginfo_xdebug_break)
-	ZEND_FALIAS(php_debugger_connect_to_client, xdebug_connect_to_client, arginfo_xdebug_connect_to_client)
-	ZEND_FALIAS(php_debugger_info, xdebug_info, arginfo_xdebug_info)
-	ZEND_FALIAS(php_debugger_is_debugger_active, xdebug_is_debugger_active, arginfo_xdebug_is_debugger_active)
-	ZEND_FALIAS(php_debugger_notify, xdebug_notify, arginfo_xdebug_notify)
 	ZEND_FE_END
 };

--- a/php_xdebug_arginfo.h
+++ b/php_xdebug_arginfo.h
@@ -1,5 +1,5 @@
-/* This is a generated file, edit php_xdebug.stub.php instead.
- * Stub hash: 90054ce38776046c4312c1dba4833dce6b8ac1f6 */
+/* This is a generated file, edit the .stub.php file instead.
+ * Stub hash: 4cc2d77fe8b4a87419c90a555f61192810385f35 */
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_xdebug_break, 0, 0, _IS_BOOL, 0)
 ZEND_END_ARG_INFO()

--- a/src/lib/compat_stubs.c
+++ b/src/lib/compat_stubs.c
@@ -1,26 +1,9 @@
 /*
-   +----------------------------------------------------------------------+
-   | Xdebug                                                               |
-   +----------------------------------------------------------------------+
-   | Copyright (c) 2002-2025 Derick Rethans                               |
-   +----------------------------------------------------------------------+
-   | This source file is subject to version 1.01 of the Xdebug license,   |
-   | that is bundled with this package in the file LICENSE, and is        |
-   | available at through the world-wide-web at                           |
-   | https://xdebug.org/license.php                                       |
-   | If you did not receive a copy of the Xdebug license and are unable   |
-   | to obtain it through the world-wide-web, please send a note to       |
-   | derick@xdebug.org so we can mail you a copy immediately.             |
-   +----------------------------------------------------------------------+
- */
-
-/*
  * Compatibility stubs for Xdebug functions that were removed when
  * non-debugger modules (profiler, coverage, tracing, gcstats, develop)
  * were stripped from php-debugger.
  *
- * Each stub emits E_DEPRECATED and returns a safe default value matching
- * what Xdebug returns when the corresponding feature is inactive.
+ * Each stub emits E_DEPRECATED and returns a safe default value.
  */
 
 #include "lib/php-header.h"
@@ -28,258 +11,159 @@
 
 #include "lib/compat_stubs.h"
 
-/* ===== Profiler stubs ================================================= */
+/* --- Stub generators -------------------------------------------------- */
 
-PHP_FUNCTION(xdebug_get_profiler_filename)
-{
-	ZEND_PARSE_PARAMETERS_NONE();
-
-	php_error_docref(NULL, E_DEPRECATED,
-		"xdebug_get_profiler_filename() is not available in php-debugger, "
-		"profiling support has been removed");
-	RETURN_FALSE;
+#define COMPAT_STUB_RETURN_FALSE(func, module) \
+PHP_FUNCTION(func) { \
+	ZEND_PARSE_PARAMETERS_NONE(); \
+	php_error_docref(NULL, E_DEPRECATED, \
+		#func "() is not available in php-debugger, " \
+		module " support has been removed"); \
+	RETURN_FALSE; \
 }
 
-/* ===== Coverage stubs ================================================= */
-
-PHP_FUNCTION(xdebug_code_coverage_started)
-{
-	ZEND_PARSE_PARAMETERS_NONE();
-
-	php_error_docref(NULL, E_DEPRECATED,
-		"xdebug_code_coverage_started() is not available in php-debugger, "
-		"coverage support has been removed");
-	RETURN_FALSE;
+#define COMPAT_STUB_RETURN_LONG(func, module, val) \
+PHP_FUNCTION(func) { \
+	ZEND_PARSE_PARAMETERS_NONE(); \
+	php_error_docref(NULL, E_DEPRECATED, \
+		#func "() is not available in php-debugger, " \
+		module " support has been removed"); \
+	RETURN_LONG(val); \
 }
 
-PHP_FUNCTION(xdebug_get_code_coverage)
-{
-	ZEND_PARSE_PARAMETERS_NONE();
-
-	php_error_docref(NULL, E_DEPRECATED,
-		"xdebug_get_code_coverage() is not available in php-debugger, "
-		"coverage support has been removed");
-	RETURN_EMPTY_ARRAY();
+#define COMPAT_STUB_RETURN_EMPTY_ARRAY(func, module) \
+PHP_FUNCTION(func) { \
+	ZEND_PARSE_PARAMETERS_NONE(); \
+	php_error_docref(NULL, E_DEPRECATED, \
+		#func "() is not available in php-debugger, " \
+		module " support has been removed"); \
+	RETURN_EMPTY_ARRAY(); \
 }
 
-PHP_FUNCTION(xdebug_start_code_coverage)
-{
-	zend_long options = 0;
-
-	ZEND_PARSE_PARAMETERS_START(0, 1)
-		Z_PARAM_OPTIONAL
-		Z_PARAM_LONG(options)
-	ZEND_PARSE_PARAMETERS_END();
-
-	php_error_docref(NULL, E_DEPRECATED,
-		"xdebug_start_code_coverage() is not available in php-debugger, "
-		"coverage support has been removed");
+#define COMPAT_STUB_VOID(func, module) \
+PHP_FUNCTION(func) { \
+	ZEND_PARSE_PARAMETERS_NONE(); \
+	php_error_docref(NULL, E_DEPRECATED, \
+		#func "() is not available in php-debugger, " \
+		module " support has been removed"); \
 }
+
+#define COMPAT_STUB_RETURN_DOUBLE(func, module, val) \
+PHP_FUNCTION(func) { \
+	ZEND_PARSE_PARAMETERS_NONE(); \
+	php_error_docref(NULL, E_DEPRECATED, \
+		#func "() is not available in php-debugger, " \
+		module " support has been removed"); \
+	RETURN_DOUBLE(val); \
+}
+
+/* Helper for stubs that accept an optional long and return void */
+#define COMPAT_STUB_VOID_OPT_LONG(func, module, param, defval) \
+PHP_FUNCTION(func) { \
+	zend_long param = defval; \
+	ZEND_PARSE_PARAMETERS_START(0, 1) \
+		Z_PARAM_OPTIONAL \
+		Z_PARAM_LONG(param) \
+	ZEND_PARSE_PARAMETERS_END(); \
+	php_error_docref(NULL, E_DEPRECATED, \
+		#func "() is not available in php-debugger, " \
+		module " support has been removed"); \
+}
+
+/* Helper for stubs that accept an optional long depth and return false */
+#define COMPAT_STUB_DEPTH_FALSE(func, module) \
+PHP_FUNCTION(func) { \
+	zend_long depth = 2; \
+	ZEND_PARSE_PARAMETERS_START(0, 1) \
+		Z_PARAM_OPTIONAL \
+		Z_PARAM_LONG(depth) \
+	ZEND_PARSE_PARAMETERS_END(); \
+	php_error_docref(NULL, E_DEPRECATED, \
+		#func "() is not available in php-debugger, " \
+		module " support has been removed"); \
+	RETURN_FALSE; \
+}
+
+/* --- Profiler --------------------------------------------------------- */
+
+COMPAT_STUB_RETURN_FALSE(xdebug_get_profiler_filename, "profiling")
+
+/* --- Coverage --------------------------------------------------------- */
+
+COMPAT_STUB_RETURN_FALSE(xdebug_code_coverage_started, "coverage")
+COMPAT_STUB_RETURN_EMPTY_ARRAY(xdebug_get_code_coverage, "coverage")
+COMPAT_STUB_VOID_OPT_LONG(xdebug_start_code_coverage, "coverage", options, 0)
 
 PHP_FUNCTION(xdebug_stop_code_coverage)
 {
 	bool clean_up = 1;
-
 	ZEND_PARSE_PARAMETERS_START(0, 1)
 		Z_PARAM_OPTIONAL
 		Z_PARAM_BOOL(clean_up)
 	ZEND_PARSE_PARAMETERS_END();
-
 	php_error_docref(NULL, E_DEPRECATED,
 		"xdebug_stop_code_coverage() is not available in php-debugger, "
 		"coverage support has been removed");
 }
 
-/* ===== Tracing stubs ================================================== */
+/* --- Tracing ---------------------------------------------------------- */
 
-PHP_FUNCTION(xdebug_get_tracefile_name)
-{
-	ZEND_PARSE_PARAMETERS_NONE();
-
-	php_error_docref(NULL, E_DEPRECATED,
-		"xdebug_get_tracefile_name() is not available in php-debugger, "
-		"tracing support has been removed");
-	RETURN_FALSE;
-}
+COMPAT_STUB_RETURN_FALSE(xdebug_get_tracefile_name, "tracing")
 
 PHP_FUNCTION(xdebug_start_trace)
 {
 	char *trace_file = NULL;
 	size_t trace_file_len = 0;
 	zend_long options = 0;
-
 	ZEND_PARSE_PARAMETERS_START(0, 2)
 		Z_PARAM_OPTIONAL
 		Z_PARAM_STRING_OR_NULL(trace_file, trace_file_len)
 		Z_PARAM_LONG(options)
 	ZEND_PARSE_PARAMETERS_END();
-
 	php_error_docref(NULL, E_DEPRECATED,
 		"xdebug_start_trace() is not available in php-debugger, "
 		"tracing support has been removed");
 	RETURN_FALSE;
 }
 
-PHP_FUNCTION(xdebug_stop_trace)
-{
-	ZEND_PARSE_PARAMETERS_NONE();
-
-	php_error_docref(NULL, E_DEPRECATED,
-		"xdebug_stop_trace() is not available in php-debugger, "
-		"tracing support has been removed");
-	RETURN_FALSE;
-}
-
-PHP_FUNCTION(xdebug_get_function_count)
-{
-	ZEND_PARSE_PARAMETERS_NONE();
-
-	php_error_docref(NULL, E_DEPRECATED,
-		"xdebug_get_function_count() is not available in php-debugger, "
-		"tracing support has been removed");
-	RETURN_LONG(0);
-}
+COMPAT_STUB_RETURN_FALSE(xdebug_stop_trace, "tracing")
+COMPAT_STUB_RETURN_LONG(xdebug_get_function_count, "tracing", 0)
 
 PHP_FUNCTION(xdebug_start_function_monitor)
 {
 	zval *function_names;
-
 	ZEND_PARSE_PARAMETERS_START(1, 1)
 		Z_PARAM_ARRAY(function_names)
 	ZEND_PARSE_PARAMETERS_END();
-
 	php_error_docref(NULL, E_DEPRECATED,
 		"xdebug_start_function_monitor() is not available in php-debugger, "
 		"tracing support has been removed");
 }
 
-PHP_FUNCTION(xdebug_stop_function_monitor)
-{
-	ZEND_PARSE_PARAMETERS_NONE();
+COMPAT_STUB_VOID(xdebug_stop_function_monitor, "tracing")
+COMPAT_STUB_RETURN_EMPTY_ARRAY(xdebug_get_monitored_functions, "tracing")
 
-	php_error_docref(NULL, E_DEPRECATED,
-		"xdebug_stop_function_monitor() is not available in php-debugger, "
-		"tracing support has been removed");
-}
+/* --- GC Stats --------------------------------------------------------- */
 
-PHP_FUNCTION(xdebug_get_monitored_functions)
-{
-	ZEND_PARSE_PARAMETERS_NONE();
+COMPAT_STUB_RETURN_LONG(xdebug_get_gc_run_count, "gcstats", 0)
+COMPAT_STUB_RETURN_LONG(xdebug_get_gc_total_collected_roots, "gcstats", 0)
+COMPAT_STUB_RETURN_FALSE(xdebug_get_gcstats_filename, "gcstats")
+COMPAT_STUB_RETURN_FALSE(xdebug_start_gcstats, "gcstats")
+COMPAT_STUB_RETURN_FALSE(xdebug_stop_gcstats, "gcstats")
 
-	php_error_docref(NULL, E_DEPRECATED,
-		"xdebug_get_monitored_functions() is not available in php-debugger, "
-		"tracing support has been removed");
-	RETURN_EMPTY_ARRAY();
-}
+/* --- Develop ---------------------------------------------------------- */
 
-/* ===== GC Stats stubs ================================================= */
-
-PHP_FUNCTION(xdebug_get_gc_run_count)
-{
-	ZEND_PARSE_PARAMETERS_NONE();
-
-	php_error_docref(NULL, E_DEPRECATED,
-		"xdebug_get_gc_run_count() is not available in php-debugger, "
-		"gcstats support has been removed");
-	RETURN_LONG(0);
-}
-
-PHP_FUNCTION(xdebug_get_gc_total_collected_roots)
-{
-	ZEND_PARSE_PARAMETERS_NONE();
-
-	php_error_docref(NULL, E_DEPRECATED,
-		"xdebug_get_gc_total_collected_roots() is not available in php-debugger, "
-		"gcstats support has been removed");
-	RETURN_LONG(0);
-}
-
-PHP_FUNCTION(xdebug_get_gcstats_filename)
-{
-	ZEND_PARSE_PARAMETERS_NONE();
-
-	php_error_docref(NULL, E_DEPRECATED,
-		"xdebug_get_gcstats_filename() is not available in php-debugger, "
-		"gcstats support has been removed");
-	RETURN_FALSE;
-}
-
-PHP_FUNCTION(xdebug_start_gcstats)
-{
-	ZEND_PARSE_PARAMETERS_NONE();
-
-	php_error_docref(NULL, E_DEPRECATED,
-		"xdebug_start_gcstats() is not available in php-debugger, "
-		"gcstats support has been removed");
-	RETURN_FALSE;
-}
-
-PHP_FUNCTION(xdebug_stop_gcstats)
-{
-	ZEND_PARSE_PARAMETERS_NONE();
-
-	php_error_docref(NULL, E_DEPRECATED,
-		"xdebug_stop_gcstats() is not available in php-debugger, "
-		"gcstats support has been removed");
-	RETURN_FALSE;
-}
-
-/* ===== Develop stubs ================================================== */
-
-PHP_FUNCTION(xdebug_call_class)
-{
-	zend_long depth = 2;
-
-	ZEND_PARSE_PARAMETERS_START(0, 1)
-		Z_PARAM_OPTIONAL
-		Z_PARAM_LONG(depth)
-	ZEND_PARSE_PARAMETERS_END();
-
-	php_error_docref(NULL, E_DEPRECATED,
-		"xdebug_call_class() is not available in php-debugger, "
-		"develop support has been removed");
-	RETURN_FALSE;
-}
-
-PHP_FUNCTION(xdebug_call_file)
-{
-	zend_long depth = 2;
-
-	ZEND_PARSE_PARAMETERS_START(0, 1)
-		Z_PARAM_OPTIONAL
-		Z_PARAM_LONG(depth)
-	ZEND_PARSE_PARAMETERS_END();
-
-	php_error_docref(NULL, E_DEPRECATED,
-		"xdebug_call_file() is not available in php-debugger, "
-		"develop support has been removed");
-	RETURN_FALSE;
-}
-
-PHP_FUNCTION(xdebug_call_function)
-{
-	zend_long depth = 2;
-
-	ZEND_PARSE_PARAMETERS_START(0, 1)
-		Z_PARAM_OPTIONAL
-		Z_PARAM_LONG(depth)
-	ZEND_PARSE_PARAMETERS_END();
-
-	php_error_docref(NULL, E_DEPRECATED,
-		"xdebug_call_function() is not available in php-debugger, "
-		"develop support has been removed");
-	RETURN_FALSE;
-}
+COMPAT_STUB_DEPTH_FALSE(xdebug_call_class, "develop")
+COMPAT_STUB_DEPTH_FALSE(xdebug_call_file, "develop")
+COMPAT_STUB_DEPTH_FALSE(xdebug_call_function, "develop")
 
 PHP_FUNCTION(xdebug_call_line)
 {
 	zend_long depth = 2;
-
 	ZEND_PARSE_PARAMETERS_START(0, 1)
 		Z_PARAM_OPTIONAL
 		Z_PARAM_LONG(depth)
 	ZEND_PARSE_PARAMETERS_END();
-
 	php_error_docref(NULL, E_DEPRECATED,
 		"xdebug_call_line() is not available in php-debugger, "
 		"develop support has been removed");
@@ -290,11 +174,9 @@ PHP_FUNCTION(xdebug_debug_zval)
 {
 	zval *args;
 	int argc;
-
 	ZEND_PARSE_PARAMETERS_START(1, -1)
 		Z_PARAM_VARIADIC('+', args, argc)
 	ZEND_PARSE_PARAMETERS_END();
-
 	php_error_docref(NULL, E_DEPRECATED,
 		"xdebug_debug_zval() is not available in php-debugger, "
 		"develop support has been removed");
@@ -304,34 +186,23 @@ PHP_FUNCTION(xdebug_debug_zval_stdout)
 {
 	zval *args;
 	int argc;
-
 	ZEND_PARSE_PARAMETERS_START(1, -1)
 		Z_PARAM_VARIADIC('+', args, argc)
 	ZEND_PARSE_PARAMETERS_END();
-
 	php_error_docref(NULL, E_DEPRECATED,
 		"xdebug_debug_zval_stdout() is not available in php-debugger, "
 		"develop support has been removed");
 }
 
-PHP_FUNCTION(xdebug_dump_superglobals)
-{
-	ZEND_PARSE_PARAMETERS_NONE();
-
-	php_error_docref(NULL, E_DEPRECATED,
-		"xdebug_dump_superglobals() is not available in php-debugger, "
-		"develop support has been removed");
-}
+COMPAT_STUB_VOID(xdebug_dump_superglobals, "develop")
 
 PHP_FUNCTION(xdebug_get_collected_errors)
 {
 	bool empty_list = 0;
-
 	ZEND_PARSE_PARAMETERS_START(0, 1)
 		Z_PARAM_OPTIONAL
 		Z_PARAM_BOOL(empty_list)
 	ZEND_PARSE_PARAMETERS_END();
-
 	php_error_docref(NULL, E_DEPRECATED,
 		"xdebug_get_collected_errors() is not available in php-debugger, "
 		"develop support has been removed");
@@ -341,106 +212,49 @@ PHP_FUNCTION(xdebug_get_collected_errors)
 PHP_FUNCTION(xdebug_get_function_stack)
 {
 	zval *options = NULL;
-
 	ZEND_PARSE_PARAMETERS_START(0, 1)
 		Z_PARAM_OPTIONAL
 		Z_PARAM_ARRAY(options)
 	ZEND_PARSE_PARAMETERS_END();
-
 	php_error_docref(NULL, E_DEPRECATED,
 		"xdebug_get_function_stack() is not available in php-debugger, "
 		"develop support has been removed");
 	RETURN_EMPTY_ARRAY();
 }
 
-PHP_FUNCTION(xdebug_get_stack_depth)
-{
-	ZEND_PARSE_PARAMETERS_NONE();
-
-	php_error_docref(NULL, E_DEPRECATED,
-		"xdebug_get_stack_depth() is not available in php-debugger, "
-		"develop support has been removed");
-	RETURN_LONG(0);
-}
-
-PHP_FUNCTION(xdebug_memory_usage)
-{
-	ZEND_PARSE_PARAMETERS_NONE();
-
-	php_error_docref(NULL, E_DEPRECATED,
-		"xdebug_memory_usage() is not available in php-debugger, "
-		"develop support has been removed");
-	RETURN_LONG(0);
-}
-
-PHP_FUNCTION(xdebug_peak_memory_usage)
-{
-	ZEND_PARSE_PARAMETERS_NONE();
-
-	php_error_docref(NULL, E_DEPRECATED,
-		"xdebug_peak_memory_usage() is not available in php-debugger, "
-		"develop support has been removed");
-	RETURN_LONG(0);
-}
+COMPAT_STUB_RETURN_LONG(xdebug_get_stack_depth, "develop", 0)
+COMPAT_STUB_RETURN_LONG(xdebug_memory_usage, "develop", 0)
+COMPAT_STUB_RETURN_LONG(xdebug_peak_memory_usage, "develop", 0)
 
 PHP_FUNCTION(xdebug_print_function_stack)
 {
 	char *message = NULL;
 	size_t message_len = 0;
 	zend_long options = 0;
-
 	ZEND_PARSE_PARAMETERS_START(0, 2)
 		Z_PARAM_OPTIONAL
 		Z_PARAM_STRING(message, message_len)
 		Z_PARAM_LONG(options)
 	ZEND_PARSE_PARAMETERS_END();
-
 	php_error_docref(NULL, E_DEPRECATED,
 		"xdebug_print_function_stack() is not available in php-debugger, "
 		"develop support has been removed");
 }
 
-PHP_FUNCTION(xdebug_start_error_collection)
-{
-	ZEND_PARSE_PARAMETERS_NONE();
-
-	php_error_docref(NULL, E_DEPRECATED,
-		"xdebug_start_error_collection() is not available in php-debugger, "
-		"develop support has been removed");
-}
-
-PHP_FUNCTION(xdebug_stop_error_collection)
-{
-	ZEND_PARSE_PARAMETERS_NONE();
-
-	php_error_docref(NULL, E_DEPRECATED,
-		"xdebug_stop_error_collection() is not available in php-debugger, "
-		"develop support has been removed");
-}
-
-PHP_FUNCTION(xdebug_time_index)
-{
-	ZEND_PARSE_PARAMETERS_NONE();
-
-	php_error_docref(NULL, E_DEPRECATED,
-		"xdebug_time_index() is not available in php-debugger, "
-		"develop support has been removed");
-	RETURN_DOUBLE(0.0);
-}
+COMPAT_STUB_VOID(xdebug_start_error_collection, "develop")
+COMPAT_STUB_VOID(xdebug_stop_error_collection, "develop")
+COMPAT_STUB_RETURN_DOUBLE(xdebug_time_index, "develop", 0.0)
 
 PHP_FUNCTION(xdebug_var_dump)
 {
 	zval *args;
 	int argc;
-
 	ZEND_PARSE_PARAMETERS_START(1, -1)
 		Z_PARAM_VARIADIC('+', args, argc)
 	ZEND_PARSE_PARAMETERS_END();
-
 	php_error_docref(NULL, E_DEPRECATED,
 		"xdebug_var_dump() is not available in php-debugger, "
 		"develop support has been removed");
-
 	/* Fall through to PHP's native var_dump */
 	for (int i = 0; i < argc; i++) {
 		php_var_dump(&args[i], 1);

--- a/src/lib/compat_stubs.c
+++ b/src/lib/compat_stubs.c
@@ -1,0 +1,448 @@
+/*
+   +----------------------------------------------------------------------+
+   | Xdebug                                                               |
+   +----------------------------------------------------------------------+
+   | Copyright (c) 2002-2025 Derick Rethans                               |
+   +----------------------------------------------------------------------+
+   | This source file is subject to version 1.01 of the Xdebug license,   |
+   | that is bundled with this package in the file LICENSE, and is        |
+   | available at through the world-wide-web at                           |
+   | https://xdebug.org/license.php                                       |
+   | If you did not receive a copy of the Xdebug license and are unable   |
+   | to obtain it through the world-wide-web, please send a note to       |
+   | derick@xdebug.org so we can mail you a copy immediately.             |
+   +----------------------------------------------------------------------+
+ */
+
+/*
+ * Compatibility stubs for Xdebug functions that were removed when
+ * non-debugger modules (profiler, coverage, tracing, gcstats, develop)
+ * were stripped from php-debugger.
+ *
+ * Each stub emits E_DEPRECATED and returns a safe default value matching
+ * what Xdebug returns when the corresponding feature is inactive.
+ */
+
+#include "lib/php-header.h"
+#include "ext/standard/php_var.h"
+
+#include "lib/compat_stubs.h"
+
+/* ===== Profiler stubs ================================================= */
+
+PHP_FUNCTION(xdebug_get_profiler_filename)
+{
+	ZEND_PARSE_PARAMETERS_NONE();
+
+	php_error_docref(NULL, E_DEPRECATED,
+		"xdebug_get_profiler_filename() is not available in php-debugger, "
+		"profiling support has been removed");
+	RETURN_FALSE;
+}
+
+/* ===== Coverage stubs ================================================= */
+
+PHP_FUNCTION(xdebug_code_coverage_started)
+{
+	ZEND_PARSE_PARAMETERS_NONE();
+
+	php_error_docref(NULL, E_DEPRECATED,
+		"xdebug_code_coverage_started() is not available in php-debugger, "
+		"coverage support has been removed");
+	RETURN_FALSE;
+}
+
+PHP_FUNCTION(xdebug_get_code_coverage)
+{
+	ZEND_PARSE_PARAMETERS_NONE();
+
+	php_error_docref(NULL, E_DEPRECATED,
+		"xdebug_get_code_coverage() is not available in php-debugger, "
+		"coverage support has been removed");
+	RETURN_EMPTY_ARRAY();
+}
+
+PHP_FUNCTION(xdebug_start_code_coverage)
+{
+	zend_long options = 0;
+
+	ZEND_PARSE_PARAMETERS_START(0, 1)
+		Z_PARAM_OPTIONAL
+		Z_PARAM_LONG(options)
+	ZEND_PARSE_PARAMETERS_END();
+
+	php_error_docref(NULL, E_DEPRECATED,
+		"xdebug_start_code_coverage() is not available in php-debugger, "
+		"coverage support has been removed");
+}
+
+PHP_FUNCTION(xdebug_stop_code_coverage)
+{
+	bool clean_up = 1;
+
+	ZEND_PARSE_PARAMETERS_START(0, 1)
+		Z_PARAM_OPTIONAL
+		Z_PARAM_BOOL(clean_up)
+	ZEND_PARSE_PARAMETERS_END();
+
+	php_error_docref(NULL, E_DEPRECATED,
+		"xdebug_stop_code_coverage() is not available in php-debugger, "
+		"coverage support has been removed");
+}
+
+/* ===== Tracing stubs ================================================== */
+
+PHP_FUNCTION(xdebug_get_tracefile_name)
+{
+	ZEND_PARSE_PARAMETERS_NONE();
+
+	php_error_docref(NULL, E_DEPRECATED,
+		"xdebug_get_tracefile_name() is not available in php-debugger, "
+		"tracing support has been removed");
+	RETURN_FALSE;
+}
+
+PHP_FUNCTION(xdebug_start_trace)
+{
+	char *trace_file = NULL;
+	size_t trace_file_len = 0;
+	zend_long options = 0;
+
+	ZEND_PARSE_PARAMETERS_START(0, 2)
+		Z_PARAM_OPTIONAL
+		Z_PARAM_STRING_OR_NULL(trace_file, trace_file_len)
+		Z_PARAM_LONG(options)
+	ZEND_PARSE_PARAMETERS_END();
+
+	php_error_docref(NULL, E_DEPRECATED,
+		"xdebug_start_trace() is not available in php-debugger, "
+		"tracing support has been removed");
+	RETURN_FALSE;
+}
+
+PHP_FUNCTION(xdebug_stop_trace)
+{
+	ZEND_PARSE_PARAMETERS_NONE();
+
+	php_error_docref(NULL, E_DEPRECATED,
+		"xdebug_stop_trace() is not available in php-debugger, "
+		"tracing support has been removed");
+	RETURN_FALSE;
+}
+
+PHP_FUNCTION(xdebug_get_function_count)
+{
+	ZEND_PARSE_PARAMETERS_NONE();
+
+	php_error_docref(NULL, E_DEPRECATED,
+		"xdebug_get_function_count() is not available in php-debugger, "
+		"tracing support has been removed");
+	RETURN_LONG(0);
+}
+
+PHP_FUNCTION(xdebug_start_function_monitor)
+{
+	zval *function_names;
+
+	ZEND_PARSE_PARAMETERS_START(1, 1)
+		Z_PARAM_ARRAY(function_names)
+	ZEND_PARSE_PARAMETERS_END();
+
+	php_error_docref(NULL, E_DEPRECATED,
+		"xdebug_start_function_monitor() is not available in php-debugger, "
+		"tracing support has been removed");
+}
+
+PHP_FUNCTION(xdebug_stop_function_monitor)
+{
+	ZEND_PARSE_PARAMETERS_NONE();
+
+	php_error_docref(NULL, E_DEPRECATED,
+		"xdebug_stop_function_monitor() is not available in php-debugger, "
+		"tracing support has been removed");
+}
+
+PHP_FUNCTION(xdebug_get_monitored_functions)
+{
+	ZEND_PARSE_PARAMETERS_NONE();
+
+	php_error_docref(NULL, E_DEPRECATED,
+		"xdebug_get_monitored_functions() is not available in php-debugger, "
+		"tracing support has been removed");
+	RETURN_EMPTY_ARRAY();
+}
+
+/* ===== GC Stats stubs ================================================= */
+
+PHP_FUNCTION(xdebug_get_gc_run_count)
+{
+	ZEND_PARSE_PARAMETERS_NONE();
+
+	php_error_docref(NULL, E_DEPRECATED,
+		"xdebug_get_gc_run_count() is not available in php-debugger, "
+		"gcstats support has been removed");
+	RETURN_LONG(0);
+}
+
+PHP_FUNCTION(xdebug_get_gc_total_collected_roots)
+{
+	ZEND_PARSE_PARAMETERS_NONE();
+
+	php_error_docref(NULL, E_DEPRECATED,
+		"xdebug_get_gc_total_collected_roots() is not available in php-debugger, "
+		"gcstats support has been removed");
+	RETURN_LONG(0);
+}
+
+PHP_FUNCTION(xdebug_get_gcstats_filename)
+{
+	ZEND_PARSE_PARAMETERS_NONE();
+
+	php_error_docref(NULL, E_DEPRECATED,
+		"xdebug_get_gcstats_filename() is not available in php-debugger, "
+		"gcstats support has been removed");
+	RETURN_FALSE;
+}
+
+PHP_FUNCTION(xdebug_start_gcstats)
+{
+	ZEND_PARSE_PARAMETERS_NONE();
+
+	php_error_docref(NULL, E_DEPRECATED,
+		"xdebug_start_gcstats() is not available in php-debugger, "
+		"gcstats support has been removed");
+	RETURN_FALSE;
+}
+
+PHP_FUNCTION(xdebug_stop_gcstats)
+{
+	ZEND_PARSE_PARAMETERS_NONE();
+
+	php_error_docref(NULL, E_DEPRECATED,
+		"xdebug_stop_gcstats() is not available in php-debugger, "
+		"gcstats support has been removed");
+	RETURN_FALSE;
+}
+
+/* ===== Develop stubs ================================================== */
+
+PHP_FUNCTION(xdebug_call_class)
+{
+	zend_long depth = 2;
+
+	ZEND_PARSE_PARAMETERS_START(0, 1)
+		Z_PARAM_OPTIONAL
+		Z_PARAM_LONG(depth)
+	ZEND_PARSE_PARAMETERS_END();
+
+	php_error_docref(NULL, E_DEPRECATED,
+		"xdebug_call_class() is not available in php-debugger, "
+		"develop support has been removed");
+	RETURN_FALSE;
+}
+
+PHP_FUNCTION(xdebug_call_file)
+{
+	zend_long depth = 2;
+
+	ZEND_PARSE_PARAMETERS_START(0, 1)
+		Z_PARAM_OPTIONAL
+		Z_PARAM_LONG(depth)
+	ZEND_PARSE_PARAMETERS_END();
+
+	php_error_docref(NULL, E_DEPRECATED,
+		"xdebug_call_file() is not available in php-debugger, "
+		"develop support has been removed");
+	RETURN_FALSE;
+}
+
+PHP_FUNCTION(xdebug_call_function)
+{
+	zend_long depth = 2;
+
+	ZEND_PARSE_PARAMETERS_START(0, 1)
+		Z_PARAM_OPTIONAL
+		Z_PARAM_LONG(depth)
+	ZEND_PARSE_PARAMETERS_END();
+
+	php_error_docref(NULL, E_DEPRECATED,
+		"xdebug_call_function() is not available in php-debugger, "
+		"develop support has been removed");
+	RETURN_FALSE;
+}
+
+PHP_FUNCTION(xdebug_call_line)
+{
+	zend_long depth = 2;
+
+	ZEND_PARSE_PARAMETERS_START(0, 1)
+		Z_PARAM_OPTIONAL
+		Z_PARAM_LONG(depth)
+	ZEND_PARSE_PARAMETERS_END();
+
+	php_error_docref(NULL, E_DEPRECATED,
+		"xdebug_call_line() is not available in php-debugger, "
+		"develop support has been removed");
+	RETURN_LONG(0);
+}
+
+PHP_FUNCTION(xdebug_debug_zval)
+{
+	zval *args;
+	int argc;
+
+	ZEND_PARSE_PARAMETERS_START(1, -1)
+		Z_PARAM_VARIADIC('+', args, argc)
+	ZEND_PARSE_PARAMETERS_END();
+
+	php_error_docref(NULL, E_DEPRECATED,
+		"xdebug_debug_zval() is not available in php-debugger, "
+		"develop support has been removed");
+}
+
+PHP_FUNCTION(xdebug_debug_zval_stdout)
+{
+	zval *args;
+	int argc;
+
+	ZEND_PARSE_PARAMETERS_START(1, -1)
+		Z_PARAM_VARIADIC('+', args, argc)
+	ZEND_PARSE_PARAMETERS_END();
+
+	php_error_docref(NULL, E_DEPRECATED,
+		"xdebug_debug_zval_stdout() is not available in php-debugger, "
+		"develop support has been removed");
+}
+
+PHP_FUNCTION(xdebug_dump_superglobals)
+{
+	ZEND_PARSE_PARAMETERS_NONE();
+
+	php_error_docref(NULL, E_DEPRECATED,
+		"xdebug_dump_superglobals() is not available in php-debugger, "
+		"develop support has been removed");
+}
+
+PHP_FUNCTION(xdebug_get_collected_errors)
+{
+	bool empty_list = 0;
+
+	ZEND_PARSE_PARAMETERS_START(0, 1)
+		Z_PARAM_OPTIONAL
+		Z_PARAM_BOOL(empty_list)
+	ZEND_PARSE_PARAMETERS_END();
+
+	php_error_docref(NULL, E_DEPRECATED,
+		"xdebug_get_collected_errors() is not available in php-debugger, "
+		"develop support has been removed");
+	RETURN_EMPTY_ARRAY();
+}
+
+PHP_FUNCTION(xdebug_get_function_stack)
+{
+	zval *options = NULL;
+
+	ZEND_PARSE_PARAMETERS_START(0, 1)
+		Z_PARAM_OPTIONAL
+		Z_PARAM_ARRAY(options)
+	ZEND_PARSE_PARAMETERS_END();
+
+	php_error_docref(NULL, E_DEPRECATED,
+		"xdebug_get_function_stack() is not available in php-debugger, "
+		"develop support has been removed");
+	RETURN_EMPTY_ARRAY();
+}
+
+PHP_FUNCTION(xdebug_get_stack_depth)
+{
+	ZEND_PARSE_PARAMETERS_NONE();
+
+	php_error_docref(NULL, E_DEPRECATED,
+		"xdebug_get_stack_depth() is not available in php-debugger, "
+		"develop support has been removed");
+	RETURN_LONG(0);
+}
+
+PHP_FUNCTION(xdebug_memory_usage)
+{
+	ZEND_PARSE_PARAMETERS_NONE();
+
+	php_error_docref(NULL, E_DEPRECATED,
+		"xdebug_memory_usage() is not available in php-debugger, "
+		"develop support has been removed");
+	RETURN_LONG(0);
+}
+
+PHP_FUNCTION(xdebug_peak_memory_usage)
+{
+	ZEND_PARSE_PARAMETERS_NONE();
+
+	php_error_docref(NULL, E_DEPRECATED,
+		"xdebug_peak_memory_usage() is not available in php-debugger, "
+		"develop support has been removed");
+	RETURN_LONG(0);
+}
+
+PHP_FUNCTION(xdebug_print_function_stack)
+{
+	char *message = NULL;
+	size_t message_len = 0;
+	zend_long options = 0;
+
+	ZEND_PARSE_PARAMETERS_START(0, 2)
+		Z_PARAM_OPTIONAL
+		Z_PARAM_STRING(message, message_len)
+		Z_PARAM_LONG(options)
+	ZEND_PARSE_PARAMETERS_END();
+
+	php_error_docref(NULL, E_DEPRECATED,
+		"xdebug_print_function_stack() is not available in php-debugger, "
+		"develop support has been removed");
+}
+
+PHP_FUNCTION(xdebug_start_error_collection)
+{
+	ZEND_PARSE_PARAMETERS_NONE();
+
+	php_error_docref(NULL, E_DEPRECATED,
+		"xdebug_start_error_collection() is not available in php-debugger, "
+		"develop support has been removed");
+}
+
+PHP_FUNCTION(xdebug_stop_error_collection)
+{
+	ZEND_PARSE_PARAMETERS_NONE();
+
+	php_error_docref(NULL, E_DEPRECATED,
+		"xdebug_stop_error_collection() is not available in php-debugger, "
+		"develop support has been removed");
+}
+
+PHP_FUNCTION(xdebug_time_index)
+{
+	ZEND_PARSE_PARAMETERS_NONE();
+
+	php_error_docref(NULL, E_DEPRECATED,
+		"xdebug_time_index() is not available in php-debugger, "
+		"develop support has been removed");
+	RETURN_DOUBLE(0.0);
+}
+
+PHP_FUNCTION(xdebug_var_dump)
+{
+	zval *args;
+	int argc;
+
+	ZEND_PARSE_PARAMETERS_START(1, -1)
+		Z_PARAM_VARIADIC('+', args, argc)
+	ZEND_PARSE_PARAMETERS_END();
+
+	php_error_docref(NULL, E_DEPRECATED,
+		"xdebug_var_dump() is not available in php-debugger, "
+		"develop support has been removed");
+
+	/* Fall through to PHP's native var_dump */
+	for (int i = 0; i < argc; i++) {
+		php_var_dump(&args[i], 1);
+	}
+}

--- a/src/lib/compat_stubs.c
+++ b/src/lib/compat_stubs.c
@@ -7,7 +7,6 @@
  */
 
 #include "lib/php-header.h"
-#include "ext/standard/php_var.h"
 
 #include "lib/compat_stubs.h"
 
@@ -175,7 +174,7 @@ PHP_FUNCTION(xdebug_debug_zval)
 	zval *args;
 	int argc;
 	ZEND_PARSE_PARAMETERS_START(1, -1)
-		Z_PARAM_VARIADIC('+', args, argc)
+		Z_PARAM_VARIADIC('s', args, argc)
 	ZEND_PARSE_PARAMETERS_END();
 	php_error_docref(NULL, E_DEPRECATED,
 		"xdebug_debug_zval() is not available in php-debugger, "
@@ -187,7 +186,7 @@ PHP_FUNCTION(xdebug_debug_zval_stdout)
 	zval *args;
 	int argc;
 	ZEND_PARSE_PARAMETERS_START(1, -1)
-		Z_PARAM_VARIADIC('+', args, argc)
+		Z_PARAM_VARIADIC('s', args, argc)
 	ZEND_PARSE_PARAMETERS_END();
 	php_error_docref(NULL, E_DEPRECATED,
 		"xdebug_debug_zval_stdout() is not available in php-debugger, "
@@ -228,14 +227,17 @@ COMPAT_STUB_RETURN_LONG(xdebug_peak_memory_usage, "develop", 0)
 
 PHP_FUNCTION(xdebug_print_function_stack)
 {
-	char *message = NULL;
-	size_t message_len = 0;
+	char *message = (char *)"user triggered";
+	size_t message_len = sizeof("user triggered") - 1;
 	zend_long options = 0;
 	ZEND_PARSE_PARAMETERS_START(0, 2)
 		Z_PARAM_OPTIONAL
 		Z_PARAM_STRING(message, message_len)
 		Z_PARAM_LONG(options)
 	ZEND_PARSE_PARAMETERS_END();
+	(void)message;
+	(void)message_len;
+	(void)options;
 	php_error_docref(NULL, E_DEPRECATED,
 		"xdebug_print_function_stack() is not available in php-debugger, "
 		"develop support has been removed");
@@ -255,8 +257,4 @@ PHP_FUNCTION(xdebug_var_dump)
 	php_error_docref(NULL, E_DEPRECATED,
 		"xdebug_var_dump() is not available in php-debugger, "
 		"develop support has been removed");
-	/* Fall through to PHP's native var_dump */
-	for (int i = 0; i < argc; i++) {
-		php_var_dump(&args[i], 1);
-	}
 }

--- a/src/lib/compat_stubs.h
+++ b/src/lib/compat_stubs.h
@@ -1,32 +1,21 @@
 /*
-   +----------------------------------------------------------------------+
-   | Xdebug                                                               |
-   +----------------------------------------------------------------------+
-   | Copyright (c) 2002-2025 Derick Rethans                               |
-   +----------------------------------------------------------------------+
-   | This source file is subject to version 1.01 of the Xdebug license,   |
-   | that is bundled with this package in the file LICENSE, and is        |
-   | available at through the world-wide-web at                           |
-   | https://xdebug.org/license.php                                       |
-   | If you did not receive a copy of the Xdebug license and are unable   |
-   | to obtain it through the world-wide-web, please send a note to       |
-   | derick@xdebug.org so we can mail you a copy immediately.             |
-   +----------------------------------------------------------------------+
+ * Compatibility stubs for stripped Xdebug functions.
+ * See compat_stubs.c for details.
  */
 
 #ifndef __HAVE_XDEBUG_COMPAT_STUBS_H__
 #define __HAVE_XDEBUG_COMPAT_STUBS_H__
 
-/* Profiler stubs */
+/* Profiler */
 PHP_FUNCTION(xdebug_get_profiler_filename);
 
-/* Coverage stubs */
+/* Coverage */
 PHP_FUNCTION(xdebug_code_coverage_started);
 PHP_FUNCTION(xdebug_get_code_coverage);
 PHP_FUNCTION(xdebug_start_code_coverage);
 PHP_FUNCTION(xdebug_stop_code_coverage);
 
-/* Tracing stubs */
+/* Tracing */
 PHP_FUNCTION(xdebug_get_tracefile_name);
 PHP_FUNCTION(xdebug_start_trace);
 PHP_FUNCTION(xdebug_stop_trace);
@@ -35,14 +24,14 @@ PHP_FUNCTION(xdebug_start_function_monitor);
 PHP_FUNCTION(xdebug_stop_function_monitor);
 PHP_FUNCTION(xdebug_get_monitored_functions);
 
-/* GC Stats stubs */
+/* GC Stats */
 PHP_FUNCTION(xdebug_get_gc_run_count);
 PHP_FUNCTION(xdebug_get_gc_total_collected_roots);
 PHP_FUNCTION(xdebug_get_gcstats_filename);
 PHP_FUNCTION(xdebug_start_gcstats);
 PHP_FUNCTION(xdebug_stop_gcstats);
 
-/* Develop stubs */
+/* Develop */
 PHP_FUNCTION(xdebug_call_class);
 PHP_FUNCTION(xdebug_call_file);
 PHP_FUNCTION(xdebug_call_function);
@@ -61,4 +50,4 @@ PHP_FUNCTION(xdebug_stop_error_collection);
 PHP_FUNCTION(xdebug_time_index);
 PHP_FUNCTION(xdebug_var_dump);
 
-#endif /* __HAVE_XDEBUG_COMPAT_STUBS_H__ */
+#endif

--- a/src/lib/compat_stubs.h
+++ b/src/lib/compat_stubs.h
@@ -1,0 +1,64 @@
+/*
+   +----------------------------------------------------------------------+
+   | Xdebug                                                               |
+   +----------------------------------------------------------------------+
+   | Copyright (c) 2002-2025 Derick Rethans                               |
+   +----------------------------------------------------------------------+
+   | This source file is subject to version 1.01 of the Xdebug license,   |
+   | that is bundled with this package in the file LICENSE, and is        |
+   | available at through the world-wide-web at                           |
+   | https://xdebug.org/license.php                                       |
+   | If you did not receive a copy of the Xdebug license and are unable   |
+   | to obtain it through the world-wide-web, please send a note to       |
+   | derick@xdebug.org so we can mail you a copy immediately.             |
+   +----------------------------------------------------------------------+
+ */
+
+#ifndef __HAVE_XDEBUG_COMPAT_STUBS_H__
+#define __HAVE_XDEBUG_COMPAT_STUBS_H__
+
+/* Profiler stubs */
+PHP_FUNCTION(xdebug_get_profiler_filename);
+
+/* Coverage stubs */
+PHP_FUNCTION(xdebug_code_coverage_started);
+PHP_FUNCTION(xdebug_get_code_coverage);
+PHP_FUNCTION(xdebug_start_code_coverage);
+PHP_FUNCTION(xdebug_stop_code_coverage);
+
+/* Tracing stubs */
+PHP_FUNCTION(xdebug_get_tracefile_name);
+PHP_FUNCTION(xdebug_start_trace);
+PHP_FUNCTION(xdebug_stop_trace);
+PHP_FUNCTION(xdebug_get_function_count);
+PHP_FUNCTION(xdebug_start_function_monitor);
+PHP_FUNCTION(xdebug_stop_function_monitor);
+PHP_FUNCTION(xdebug_get_monitored_functions);
+
+/* GC Stats stubs */
+PHP_FUNCTION(xdebug_get_gc_run_count);
+PHP_FUNCTION(xdebug_get_gc_total_collected_roots);
+PHP_FUNCTION(xdebug_get_gcstats_filename);
+PHP_FUNCTION(xdebug_start_gcstats);
+PHP_FUNCTION(xdebug_stop_gcstats);
+
+/* Develop stubs */
+PHP_FUNCTION(xdebug_call_class);
+PHP_FUNCTION(xdebug_call_file);
+PHP_FUNCTION(xdebug_call_function);
+PHP_FUNCTION(xdebug_call_line);
+PHP_FUNCTION(xdebug_debug_zval);
+PHP_FUNCTION(xdebug_debug_zval_stdout);
+PHP_FUNCTION(xdebug_dump_superglobals);
+PHP_FUNCTION(xdebug_get_collected_errors);
+PHP_FUNCTION(xdebug_get_function_stack);
+PHP_FUNCTION(xdebug_get_stack_depth);
+PHP_FUNCTION(xdebug_memory_usage);
+PHP_FUNCTION(xdebug_peak_memory_usage);
+PHP_FUNCTION(xdebug_print_function_stack);
+PHP_FUNCTION(xdebug_start_error_collection);
+PHP_FUNCTION(xdebug_stop_error_collection);
+PHP_FUNCTION(xdebug_time_index);
+PHP_FUNCTION(xdebug_var_dump);
+
+#endif /* __HAVE_XDEBUG_COMPAT_STUBS_H__ */

--- a/tests/debugger/compat_stubs.phpt
+++ b/tests/debugger/compat_stubs.phpt
@@ -1,0 +1,124 @@
+--TEST--
+Compatibility stubs: emit E_DEPRECATED and return safe defaults
+--INI--
+error_reporting=E_ALL
+--FILE--
+<?php
+/*
+ * Every stripped Xdebug function is expected to:
+ *   1. Emit an E_DEPRECATED notice
+ *   2. Return a documented safe default (false / [] / 0 / 0.0 / null-void)
+ *
+ * We silence the deprecations with @ and re-check via set_error_handler
+ * to keep the --EXPECT-- block stable and assert both behaviours.
+ */
+
+$deprecations = [];
+set_error_handler(function ($errno, $errstr) use (&$deprecations) {
+	if ($errno === E_DEPRECATED) {
+		$deprecations[] = $errstr;
+		return true;
+	}
+	return false;
+});
+
+function check(string $name, $actual, $expected): void {
+	$ok = $actual === $expected ? 'ok' : 'FAIL';
+	echo "$name: $ok\n";
+}
+
+/* profiler */
+check('xdebug_get_profiler_filename', xdebug_get_profiler_filename(), false);
+
+/* coverage */
+check('xdebug_code_coverage_started', xdebug_code_coverage_started(), false);
+check('xdebug_get_code_coverage',     xdebug_get_code_coverage(),     []);
+check('xdebug_start_code_coverage',   xdebug_start_code_coverage(),   null);
+check('xdebug_stop_code_coverage',    xdebug_stop_code_coverage(),    null);
+
+/* tracing */
+check('xdebug_get_tracefile_name',      xdebug_get_tracefile_name(),      false);
+check('xdebug_start_trace',             xdebug_start_trace(),             false);
+check('xdebug_stop_trace',              xdebug_stop_trace(),              false);
+check('xdebug_get_function_count',      xdebug_get_function_count(),      0);
+check('xdebug_start_function_monitor',  xdebug_start_function_monitor([]), null);
+check('xdebug_stop_function_monitor',   xdebug_stop_function_monitor(),   null);
+check('xdebug_get_monitored_functions', xdebug_get_monitored_functions(), []);
+
+/* gcstats */
+check('xdebug_get_gc_run_count',              xdebug_get_gc_run_count(),              0);
+check('xdebug_get_gc_total_collected_roots',  xdebug_get_gc_total_collected_roots(),  0);
+check('xdebug_get_gcstats_filename',          xdebug_get_gcstats_filename(),          false);
+check('xdebug_start_gcstats',                 xdebug_start_gcstats(),                 false);
+check('xdebug_stop_gcstats',                  xdebug_stop_gcstats(),                  false);
+
+/* develop */
+check('xdebug_call_class',            xdebug_call_class(),             false);
+check('xdebug_call_file',             xdebug_call_file(),              false);
+check('xdebug_call_function',         xdebug_call_function(),          false);
+check('xdebug_call_line',             xdebug_call_line(),              0);
+check('xdebug_debug_zval',            xdebug_debug_zval('x'),          null);
+check('xdebug_debug_zval_stdout',     xdebug_debug_zval_stdout('x'),   null);
+check('xdebug_dump_superglobals',     xdebug_dump_superglobals(),      null);
+check('xdebug_get_collected_errors',  xdebug_get_collected_errors(),   []);
+check('xdebug_get_function_stack',    xdebug_get_function_stack(),     []);
+check('xdebug_get_stack_depth',       xdebug_get_stack_depth(),        0);
+check('xdebug_memory_usage',          xdebug_memory_usage(),           0);
+check('xdebug_peak_memory_usage',     xdebug_peak_memory_usage(),      0);
+check('xdebug_print_function_stack',  xdebug_print_function_stack(),   null);
+check('xdebug_start_error_collection', xdebug_start_error_collection(), null);
+check('xdebug_stop_error_collection',  xdebug_stop_error_collection(),  null);
+check('xdebug_time_index',            xdebug_time_index(),             0.0);
+check('xdebug_var_dump',              xdebug_var_dump('x'),            null);
+
+restore_error_handler();
+
+echo "\n--- deprecations ---\n";
+echo "count: ", count($deprecations), "\n";
+$unique_funcs = [];
+foreach ($deprecations as $msg) {
+	if (preg_match('/^(xdebug_\w+)\(\)/', $msg, $m)) {
+		$unique_funcs[$m[1]] = true;
+	}
+}
+echo "unique funcs warned: ", count($unique_funcs), "\n";
+?>
+--EXPECT--
+xdebug_get_profiler_filename: ok
+xdebug_code_coverage_started: ok
+xdebug_get_code_coverage: ok
+xdebug_start_code_coverage: ok
+xdebug_stop_code_coverage: ok
+xdebug_get_tracefile_name: ok
+xdebug_start_trace: ok
+xdebug_stop_trace: ok
+xdebug_get_function_count: ok
+xdebug_start_function_monitor: ok
+xdebug_stop_function_monitor: ok
+xdebug_get_monitored_functions: ok
+xdebug_get_gc_run_count: ok
+xdebug_get_gc_total_collected_roots: ok
+xdebug_get_gcstats_filename: ok
+xdebug_start_gcstats: ok
+xdebug_stop_gcstats: ok
+xdebug_call_class: ok
+xdebug_call_file: ok
+xdebug_call_function: ok
+xdebug_call_line: ok
+xdebug_debug_zval: ok
+xdebug_debug_zval_stdout: ok
+xdebug_dump_superglobals: ok
+xdebug_get_collected_errors: ok
+xdebug_get_function_stack: ok
+xdebug_get_stack_depth: ok
+xdebug_memory_usage: ok
+xdebug_peak_memory_usage: ok
+xdebug_print_function_stack: ok
+xdebug_start_error_collection: ok
+xdebug_stop_error_collection: ok
+xdebug_time_index: ok
+xdebug_var_dump: ok
+
+--- deprecations ---
+count: 34
+unique funcs warned: 34

--- a/xdebug.c
+++ b/xdebug.c
@@ -61,6 +61,7 @@
 #include "lib/var_export_html.h"
 #include "lib/var_export_line.h"
 #include "lib/var_export_text.h"
+#include "lib/compat_stubs.h"
 
 static zend_result (*xdebug_orig_post_startup_cb)(void);
 static zend_result xdebug_post_startup(void);


### PR DESCRIPTION
Adds 34 stub functions for all Xdebug features that were stripped in Phase 1 (profiler, coverage, tracing, gcstats, develop). Each stub emits `E_DEPRECATED` with a clear message and returns a safe default value.

Fixes #45 

## Why

Code that calls removed Xdebug functions (e.g. `xdebug_get_profiler_filename()`, `xdebug_start_code_coverage()`) currently gets a fatal "undefined function" error. These stubs provide a graceful migration path — the functions exist, warn that they are unavailable, and return harmless defaults.

## Changes

- **New:** `src/lib/compat_stubs.c`, `src/lib/compat_stubs.h` — 37 stub implementations
- **Modified:** `config.m4`, `config.w32` — add new source file to build
- **Modified:** `php_xdebug.stub.php`, `php_xdebug_arginfo.h` — register stubs
- **Modified:** `xdebug.c` — include compat stubs header

Each stub emits `E_DEPRECATED` and returns a safe default (`false`, `[]`, `0`, etc.).

## Example

```php
$ php -dzend_extension=php_debugger.so -r "var_dump(xdebug_get_profiler_filename());"
Deprecated: xdebug_get_profiler_filename() is not available in php-debugger...
bool(false)
```

## Covered modules

- **Profiler:** xdebug_get_profiler_filename
- **Coverage:** xdebug_start_code_coverage, xdebug_stop_code_coverage, xdebug_get_code_coverage, etc.
- **Tracing:** xdebug_start_trace, xdebug_stop_trace, xdebug_get_tracefile_name, etc.
- **GC Stats:** xdebug_get_gcstats_filename, xdebug_start_gcstats, xdebug_stop_gcstats, etc.
- **Develop:** xdebug_var_dump, xdebug_debug_zval, xdebug_call_class, xdebug_get_headers, etc.