### PR TITLE
Add FrankenPHP worker mode support  

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,54 @@
+# Keep host build artifacts (with absolute host paths baked in) out of any
+# Docker build context rooted at this repo. Without this, tests/frankenphp/
+# would inherit a broken Makefile from a prior host `phpize`/`configure`.
+.git
+.github
+.claude
+.understand-anything
+.idea
+.vscode
+
+# PHP build artifacts from running phpize/configure/make on the host.
+# Docker .dockerignore patterns do not cross directory boundaries without
+# explicit **/ — these live both at the root and nested under src/**.
+Makefile
+Makefile.*
+Makefile.fragments
+Makefile.global
+Makefile.objects
+config.status
+config.cache
+config.log
+config.nice
+configure
+configure.ac
+configure.in
+acinclude.m4
+aclocal.m4
+autom4te.cache
+build
+libtool
+ltmain.sh
+install-sh
+missing
+mkinstalldirs
+run-tests.php
+
+# Compiled objects / deps (root + nested)
+*.lo
+*.la
+*.o
+*.dep
+*.so
+*.loT
+**/*.lo
+**/*.la
+**/*.o
+**/*.dep
+**/*.so
+**/*.loT
+**/.libs
+**/.deps
+.libs
+.deps
+modules

--- a/.gitignore
+++ b/.gitignore
@@ -82,6 +82,8 @@ phpt.*
 !php_xdebug.stub.php
 !run-xdebug-tests.php
 !make-release.php
+!tests/frankenphp/**/*.php
+!tests/frankenphp/**/*.sh
 !bench.php
 !test-ini.php
 !rector.php

--- a/config.m4
+++ b/config.m4
@@ -104,7 +104,7 @@ if test "$PHP_PHP_DEBUGGER" != "no"; then
   XDEBUG_LIB_SOURCES="src/lib/usefulstuff.c src/lib/cmd_parser.c src/lib/compat.c src/lib/crc32.c src/lib/file.c src/lib/hash.c src/lib/headers.c src/lib/lib.c src/lib/llist.c src/lib/log.c src/lib/normalize_path.c src/lib/set.c src/lib/str.c src/lib/timing.c src/lib/trim.c src/lib/var.c src/lib/var_export_html.c src/lib/var_export_line.c src/lib/var_export_text.c src/lib/var_export_xml.c src/lib/xdebug_strndup.c src/lib/xml.c src/lib/compat_stubs.c"
   XDEBUG_LIB_MAPS_SOURCES="src/lib/maps/maps.c src/lib/maps/maps_private.c src/lib/maps/parser.c"
 
-  XDEBUG_DEBUGGER_SOURCES="src/debugger/com.c src/debugger/debugger.c src/debugger/handler_dbgp.c src/debugger/handlers.c src/debugger/ip_info.c"
+  XDEBUG_DEBUGGER_SOURCES="src/debugger/com.c src/debugger/debugger.c src/debugger/frankenphp.c src/debugger/handler_dbgp.c src/debugger/handlers.c src/debugger/ip_info.c"
 
   PHP_NEW_EXTENSION(php_debugger, xdebug.c $XDEBUG_BASE_SOURCES $XDEBUG_LIB_SOURCES $XDEBUG_LIB_MAPS_SOURCES $XDEBUG_DEBUGGER_SOURCES, $ext_shared,,$PHP_XDEBUG_CFLAGS,,yes)
   PHP_ADD_BUILD_DIR(PHP_EXT_BUILDDIR(php_debugger)[/src/base])

--- a/config.w32
+++ b/config.w32
@@ -6,7 +6,7 @@ if (PHP_DEBUGGER == 'yes') {
 	var XDEBUG_BASE_SOURCES="base.c ctrl_socket.c"
 	var XDEBUG_LIB_SOURCES="usefulstuff.c cmd_parser.c compat.c crc32.c file.c hash.c headers.c lib.c llist.c log.c normalize_path.c set.c str.c timing.c trim.c var.c var_export_html.c var_export_line.c var_export_text.c var_export_xml.c xdebug_strndup.c xml.c compat_stubs.c"
 	var XDEBUG_LIB_MAPS_SOURCES="maps.c maps_private.c parser.c"
-	var XDEBUG_DEBUGGER_SOURCES="com.c debugger.c handler_dbgp.c handlers.c ip_info.c"
+	var XDEBUG_DEBUGGER_SOURCES="com.c debugger.c frankenphp.c handler_dbgp.c handlers.c ip_info.c"
 
 	var files = "xdebug.c";
 

--- a/src/debugger/debugger.c
+++ b/src/debugger/debugger.c
@@ -20,6 +20,7 @@
 #include "zend_exceptions.h"
 
 #include "debugger_private.h"
+#include "frankenphp.h"
 #include "lib/log.h"
 #include "lib/var.h"
 
@@ -864,6 +865,9 @@ void xdebug_debugger_zend_shutdown(void)
 void xdebug_debugger_minit(void)
 {
 	XG_DBG(breakpoint_count) = 0;
+
+	/* Install FrankenPHP worker-mode SAPI hooks (no-op for other SAPIs). */
+	xdebug_frankenphp_minit();
 }
 
 void xdebug_debugger_minfo(void)

--- a/src/debugger/frankenphp.c
+++ b/src/debugger/frankenphp.c
@@ -1,0 +1,150 @@
+/*
+   +----------------------------------------------------------------------+
+   | Xdebug                                                               |
+   +----------------------------------------------------------------------+
+   | Copyright (c) 2002-2025 Derick Rethans                               |
+   +----------------------------------------------------------------------+
+   | This source file is subject to version 1.01 of the Xdebug license,   |
+   | that is bundled with this package in the file LICENSE, and is        |
+   | available at through the world-wide-web at                           |
+   | https://xdebug.org/license.php                                       |
+   | If you did not receive a copy of the Xdebug license and are unable   |
+   | to obtain it through the world-wide-web, please send a note to       |
+   | derick@xdebug.org so we can mail you a copy immediately.             |
+   +----------------------------------------------------------------------+
+ */
+
+#include <string.h>
+
+#include "lib/php-header.h"
+#include "SAPI.h"
+
+#include "php_xdebug.h"
+#include "com.h"
+#include "debugger.h"
+#include "frankenphp.h"
+#include "lib/lib.h"
+
+ZEND_EXTERN_MODULE_GLOBALS(xdebug)
+
+static int (*original_sapi_activate)(void)   = NULL;
+static int (*original_sapi_deactivate)(void) = NULL;
+static int is_frankenphp = 0;
+
+/* Scan a 'k=v' style string (cookies separated by ';', query string by '&')
+ * for one of the trigger variable names at a key boundary. */
+static int has_trigger_in_string(const char *str, char delim)
+{
+	static const char *triggers[] = {
+		"XDEBUG_SESSION", "XDEBUG_TRIGGER",
+		"PHP_DEBUGGER_SESSION", "PHP_DEBUGGER_TRIGGER",
+		NULL
+	};
+	const char **t;
+
+	if (!str) {
+		return 0;
+	}
+
+	for (t = triggers; *t; t++) {
+		size_t len = strlen(*t);
+		const char *p = str;
+
+		while ((p = strstr(p, *t)) != NULL) {
+			char prev = (p == str) ? delim : p[-1];
+			char next = p[len];
+
+			if ((prev == delim || prev == ' ') && next == '=') {
+				return 1;
+			}
+			p += len;
+		}
+	}
+	return 0;
+}
+
+static int has_debug_trigger(void)
+{
+	return has_trigger_in_string(SG(request_info).cookie_data, ';') ||
+	       has_trigger_in_string(SG(request_info).query_string, '&');
+}
+
+/* Per-request reset, called at the start of each FrankenPHP worker request. */
+static int xdebug_frankenphp_sapi_activate(void)
+{
+	int result = original_sapi_activate ? original_sapi_activate() : SUCCESS;
+
+	if (!XDEBUG_MODE_IS(XDEBUG_MODE_STEP_DEBUG)) {
+		return result;
+	}
+
+	/* Reset per-request debugger flags. The full RINIT path already ran once
+	 * for the worker; here we only undo state that should not leak across
+	 * requests inside the worker loop. */
+	XG_DBG(detached)            = 0;
+	XG_DBG(no_exec)             = 0;
+	XG_DBG(breakpoints_allowed) = 1;
+
+	XG_DBG(context).do_break             = 0;
+	XG_DBG(context).do_step              = 0;
+	XG_DBG(context).do_next              = 0;
+	XG_DBG(context).do_finish            = 0;
+	XG_DBG(context).do_connect_to_client = 0;
+
+	/* Trigger detection: superglobals are not yet populated this early in the
+	 * SAPI lifecycle, so we read the raw request data. If a trigger is present
+	 * (or start_with_request=yes), arm the connect-on-next-statement flag —
+	 * the existing path in xdebug_debugger_statement_call() picks it up. */
+	if (xdebug_lib_start_with_request() || has_debug_trigger()) {
+		XG_DBG(context).do_connect_to_client = 1;
+	}
+
+	/* If a debug session is still alive (e.g. user kept it open across
+	 * requests), drain any breakpoint_set / breakpoint_remove the IDE pushed
+	 * while the worker was busy. */
+	if (xdebug_is_debug_connection_active() && XG_DBG(context).handler && XG_DBG(context).handler->remote_poll_pending) {
+		XG_DBG(context).handler->remote_poll_pending(&(XG_DBG(context)));
+	}
+
+	return result;
+}
+
+/* Per-request teardown, called at the end of each FrankenPHP worker request.
+ * Tears down the DBGp session so the next request starts fresh. */
+static int xdebug_frankenphp_sapi_deactivate(void)
+{
+	if (XDEBUG_MODE_IS(XDEBUG_MODE_STEP_DEBUG) && xdebug_is_debug_connection_active()) {
+		XG_DBG(context).handler->remote_deinit(&(XG_DBG(context)));
+		xdebug_mark_debug_connection_not_active();
+	}
+
+	return original_sapi_deactivate ? original_sapi_deactivate() : SUCCESS;
+}
+
+void xdebug_frankenphp_minit(void)
+{
+	if (!sapi_module.name || strcmp(sapi_module.name, "frankenphp") != 0) {
+		return;
+	}
+
+	is_frankenphp = 1;
+
+	original_sapi_activate    = sapi_module.activate;
+	sapi_module.activate      = xdebug_frankenphp_sapi_activate;
+
+	original_sapi_deactivate  = sapi_module.deactivate;
+	sapi_module.deactivate    = xdebug_frankenphp_sapi_deactivate;
+}
+
+void xdebug_frankenphp_mshutdown(void)
+{
+	if (!is_frankenphp) {
+		return;
+	}
+
+	sapi_module.activate     = original_sapi_activate;
+	sapi_module.deactivate   = original_sapi_deactivate;
+	original_sapi_activate   = NULL;
+	original_sapi_deactivate = NULL;
+	is_frankenphp            = 0;
+}

--- a/src/debugger/frankenphp.h
+++ b/src/debugger/frankenphp.h
@@ -1,0 +1,33 @@
+/*
+   +----------------------------------------------------------------------+
+   | Xdebug                                                               |
+   +----------------------------------------------------------------------+
+   | Copyright (c) 2002-2025 Derick Rethans                               |
+   +----------------------------------------------------------------------+
+   | This source file is subject to version 1.01 of the Xdebug license,   |
+   | that is bundled with this package in the file LICENSE, and is        |
+   | available at through the world-wide-web at                           |
+   | https://xdebug.org/license.php                                       |
+   | If you did not receive a copy of the Xdebug license and are unable   |
+   | to obtain it through the world-wide-web, please send a note to       |
+   | derick@xdebug.org so we can mail you a copy immediately.             |
+   +----------------------------------------------------------------------+
+ */
+
+#ifndef __XDEBUG_DEBUGGER_FRANKENPHP_H__
+#define __XDEBUG_DEBUGGER_FRANKENPHP_H__
+
+/*
+ * FrankenPHP worker mode support.
+ *
+ * In FrankenPHP worker mode, MINIT/RINIT/RSHUTDOWN/MSHUTDOWN run once per
+ * worker (not per request). Per-request setup happens through
+ * sapi_module.activate / deactivate. We hook those to drive a per-request
+ * debugger lifecycle so the debug session is reset between requests.
+ *
+ * If the SAPI is not "frankenphp", these functions are no-ops.
+ */
+void xdebug_frankenphp_minit(void);
+void xdebug_frankenphp_mshutdown(void);
+
+#endif /* __XDEBUG_DEBUGGER_FRANKENPHP_H__ */

--- a/src/debugger/handler_dbgp.c
+++ b/src/debugger/handler_dbgp.c
@@ -67,6 +67,7 @@ xdebug_remote_handler xdebug_handler_dbgp = {
 	xdebug_dbgp_notification,
 	xdebug_dbgp_user_notify,
 	xdebug_dbgp_register_eval_id,
+	xdebug_dbgp_poll_pending,
 };
 
 static char *create_eval_key_id(int id);
@@ -3204,4 +3205,69 @@ int xdebug_dbgp_register_eval_id(xdebug_con *context, function_stack_entry *fse)
 	xdfree(key);
 
 	return ei->id;
+}
+
+/* Drain queued non-continuation DBGp commands without blocking.
+ *
+ * Used by FrankenPHP worker mode to apply breakpoint changes the IDE pushed
+ * while the worker was busy with a previous request. Continuation commands
+ * (run / step_* / stop / detach) are returned by the parser as ret == 1 and
+ * are deliberately not honored here — they are only meaningful at a stop. */
+int xdebug_dbgp_poll_pending(xdebug_con *context)
+{
+	struct timeval timeout;
+	fd_set         read_set;
+
+	if (context->socket < 0) {
+		return 0;
+	}
+
+	while (1) {
+		char            *option;
+		int              length = 0;
+		int              ret;
+		xdebug_xml_node *response;
+		int              sel;
+
+		FD_ZERO(&read_set);
+		FD_SET(context->socket, &read_set);
+		timeout.tv_sec  = 0;
+		timeout.tv_usec = 0;
+
+		sel = select(context->socket + 1, &read_set, NULL, NULL, &timeout);
+		if (sel < 0) {
+			if (errno == EINTR) {
+				continue;
+			}
+			xdebug_mark_debug_connection_not_active();
+			return 0;
+		}
+		if (sel == 0 || !FD_ISSET(context->socket, &read_set)) {
+			return 1;
+		}
+
+		option = xdebug_fd_read_line_delim(context->socket, context->buffer, FD_RL_SOCKET, '\0', &length);
+		if (!option) {
+			xdebug_mark_debug_connection_not_active();
+			return 0;
+		}
+
+		response = xdebug_xml_node_init("response");
+		xdebug_xml_add_attribute(response, "xmlns", "urn:debugger_protocol_v1");
+		xdebug_xml_add_attribute(response, "xmlns:xdebug", "https://xdebug.org/dbgp/xdebug");
+
+		ret = xdebug_dbgp_parse_option(context, option, 0, response);
+
+		if (ret != 1) {
+			send_message(context, response);
+		} else {
+			xdebug_log(
+				XLOG_CHAN_DEBUG, XLOG_WARN,
+				"FrankenPHP poll: ignoring continuation command received between requests"
+			);
+		}
+
+		xdebug_xml_node_dtor(response);
+		free(option);
+	}
 }

--- a/src/debugger/handler_dbgp.h
+++ b/src/debugger/handler_dbgp.h
@@ -97,6 +97,7 @@ int xdebug_dbgp_notification(xdebug_con *context, xdebug_str *filename, long lin
 int xdebug_dbgp_user_notify(xdebug_con *context, zend_string *filename, long lineno, zval *data);
 void XDEBUG_ATTRIBUTE_FORMAT(printf, 2, 3) xdebug_dbgp_log(int log_level, const char *fmt, ...);
 int xdebug_dbgp_register_eval_id(xdebug_con *context, function_stack_entry *fse);
+int xdebug_dbgp_poll_pending(xdebug_con *context);
 
 extern xdebug_remote_handler xdebug_handler_dbgp;
 

--- a/src/debugger/handlers.h
+++ b/src/debugger/handlers.h
@@ -159,6 +159,9 @@ struct _xdebug_remote_handler {
 
 	/* Eval ID registration and removal */
 	int (*register_eval_id)(xdebug_con *h, function_stack_entry *fse);
+
+	/* FrankenPHP worker mode: drain queued non-continuation commands */
+	int (*remote_poll_pending)(xdebug_con *h);
 };
 
 xdebug_brk_info *xdebug_brk_info_ctor(void);

--- a/tests/frankenphp/Caddyfile
+++ b/tests/frankenphp/Caddyfile
@@ -1,0 +1,11 @@
+{
+	frankenphp {
+		worker /app/worker.php
+	}
+	auto_https off
+}
+
+http://:80 {
+	root * /app
+	php_server
+}

--- a/tests/frankenphp/Dockerfile
+++ b/tests/frankenphp/Dockerfile
@@ -1,0 +1,64 @@
+# Builds php-debugger from the local checkout against FrankenPHP's bundled
+# ZTS PHP, then runs it in worker mode so the new SAPI hooks can be exercised.
+#
+# Build context = repo root:
+#   docker build -f tests/frankenphp/Dockerfile -t php-debugger-frankenphp .
+#
+# Run (host listens on 9003 for the IDE):
+#   docker run --rm -p 8080:80 \
+#     -e XDEBUG_CLIENT_HOST=host.docker.internal \
+#     -e XDEBUG_CLIENT_PORT=9003 \
+#     php-debugger-frankenphp
+
+FROM dunglas/frankenphp:1-php8.4 AS build
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        build-essential autoconf pkg-config git \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /src
+COPY . /src
+
+# `.dockerignore` at the repo root keeps stale host build artifacts
+# (Makefile, *.lo, *.dep, ... with absolute host paths baked in) out of
+# the context. `phpize --clean` here is a belt-and-braces reset in case
+# anything slipped through.
+RUN phpize --clean 2>/dev/null || true \
+ && phpize \
+ && ./configure --enable-php-debugger \
+ && make -j"$(nproc)" \
+ && cp modules/php_debugger.so "$(php-config --extension-dir)/"
+
+# ---- runtime ----
+FROM dunglas/frankenphp:1-php8.4
+
+# Copy the whole versioned extensions dir so the .so lands at the exact
+# path PHP's `extension_dir` points to.
+COPY --from=build /usr/local/lib/php/extensions/ /usr/local/lib/php/extensions/
+
+# Load as a Zend extension (not a regular extension).
+# Host / port are overridable at `docker run` time via env vars (see below)
+# — PHP INI does not support `${VAR:default}` bash-style fallback, so we
+# substitute at container startup via a tiny entrypoint instead.
+RUN { \
+      echo 'zend_extension=php_debugger.so'; \
+      echo 'xdebug.mode=debug'; \
+      echo 'xdebug.start_with_request=trigger'; \
+      echo 'xdebug.client_host=host.docker.internal'; \
+      echo 'xdebug.client_port=9003'; \
+      echo 'xdebug.discover_client_host=0'; \
+      echo 'xdebug.log=/tmp/xdebug.log'; \
+      echo 'xdebug.log_level=7'; \
+      echo 'xdebug.idekey=PHPSTORM'; \
+    } > /usr/local/etc/php/conf.d/zz-php-debugger.ini
+
+# Rewrite host/port from env vars if provided before handing off to FrankenPHP.
+COPY tests/frankenphp/entrypoint.sh /usr/local/bin/php-debugger-entrypoint.sh
+RUN chmod +x /usr/local/bin/php-debugger-entrypoint.sh
+ENTRYPOINT ["/usr/local/bin/php-debugger-entrypoint.sh"]
+CMD ["frankenphp", "run", "--config", "/etc/frankenphp/Caddyfile"]
+
+COPY tests/frankenphp/app/        /app/
+COPY tests/frankenphp/Caddyfile   /etc/frankenphp/Caddyfile
+
+EXPOSE 80

--- a/tests/frankenphp/README.md
+++ b/tests/frankenphp/README.md
@@ -1,0 +1,173 @@
+# Manual FrankenPHP worker-mode test
+
+Smoke-tests the SAPI activate/deactivate hooks added in `src/debugger/frankenphp.c`.
+
+## Build
+
+From the **repo root** (the build context must include the whole tree):
+
+```bash
+docker build -f tests/frankenphp/Dockerfile -t php-debugger-frankenphp .
+```
+
+## Run
+
+Start your IDE listening on port **9003** for incoming DBGp connections.
+
+* **PhpStorm:** *Run → Start Listening for PHP Debug Connections* (the
+  little phone icon in the toolbar should turn green).
+* **VS Code:** add a `launch.json` with `"type": "php"`, `"request":
+  "launch"`, `"port": 9003`, `"pathMappings": { "/app":
+  "${workspaceFolder}/tests/frankenphp/app" }`, then F5.
+
+Then start the container. **Bind-mount the app dir** so PhpStorm can match
+incoming breakpoint paths to your local files:
+
+```bash
+# macOS / Windows: host.docker.internal works out of the box.
+docker run --rm -p 8080:80 \
+  -v "$PWD/tests/frankenphp/app:/app" \
+  php-debugger-frankenphp
+
+# Linux: add the host-gateway alias.
+docker run --rm -p 8080:80 \
+  --add-host=host.docker.internal:host-gateway \
+  -v "$PWD/tests/frankenphp/app:/app" \
+  php-debugger-frankenphp
+
+# Override host/port from the CLI:
+docker run --rm -p 8080:80 \
+  -e XDEBUG_CLIENT_HOST=192.168.1.42 \
+  -e XDEBUG_CLIENT_PORT=9003 \
+  -v "$PWD/tests/frankenphp/app:/app" \
+  php-debugger-frankenphp
+```
+
+The `XDEBUG_CLIENT_HOST` / `XDEBUG_CLIENT_PORT` env vars are applied at
+container startup by `entrypoint.sh` (PHP INI has no native env-var
+fallback syntax).
+
+## One-time PhpStorm setup (path mapping)
+
+Without a path mapping, PhpStorm receives `breakpoint_set` for `/app/index.php`
+but doesn't know it corresponds to `tests/frankenphp/app/index.php` in your
+project. The IDE will warn:
+
+> It may be caused by path mappings misconfiguration or not synchronized
+> local and remote projects.
+
+Configure it once:
+
+1. *Settings → PHP → Servers → +*
+2. **Name:** `localhost` (any name; it just needs to exist)
+3. **Host:** `localhost` · **Port:** `8080` · **Debugger:** Xdebug
+4. ✅ **Use path mappings**
+5. In the file tree, find `tests/frankenphp/app` and set the
+   **Absolute path on the server** to `/app`.
+6. *Apply* / *OK*.
+
+### Quick connection check that bypasses path mapping
+
+To prove the DBGp connection itself is working before fighting path
+mappings, toggle *Run → Break at first line in PHP scripts* and hit:
+
+```bash
+curl -b 'XDEBUG_SESSION=PHPSTORM' http://localhost:8080/
+```
+
+PhpStorm should pause on the opening `<?php` regardless of any path config.
+If even that doesn't fire, the connection isn't being made — see the
+**Troubleshooting** section.
+
+## What to verify
+
+Open `tests/frankenphp/app/index.php` in your IDE and put a breakpoint on
+the `$pid = getmypid();` line.
+
+### 1. No trigger ⇒ no pause
+
+```bash
+curl -s http://localhost:8080/
+```
+
+Returns immediately. The IDE must not pause. `tail -f /tmp/xdebug.log`
+inside the container shows `Trigger value ... not found, so not activating`.
+
+### 2. Trigger ⇒ pause
+
+```bash
+curl -s -b 'XDEBUG_SESSION=PHPSTORM' http://localhost:8080/
+```
+
+PhpStorm pauses on the breakpoint. Resume (F9) — request completes.
+
+### 3. Same worker, multiple debug requests
+
+```bash
+for i in 1 2 3; do
+  curl -s -b 'XDEBUG_SESSION=PHPSTORM' http://localhost:8080/
+done
+```
+
+The `pid=` field in every response stays the same (one worker process), but
+the IDE pauses on **every** request. This proves the per-request
+`sapi_module.activate` reset is working — without it, only the first
+request would be debuggable.
+
+### 4. Breakpoint added between requests (the `xdebug_dbgp_poll_pending` test)
+
+This is the scenario that caught the original bug:
+
+1. Set a breakpoint on **line 4** (`$pid = getmypid();`).
+2. `curl -b 'XDEBUG_SESSION=PHPSTORM' http://localhost:8080/` → pauses on
+   line 4. Resume (F9).
+3. **Move the breakpoint to line 5** (`$now = ...`) while the worker is
+   idle. The IDE sends `breakpoint_remove` + `breakpoint_set` to the
+   socket of the (now idle) worker thread — those commands sit queued.
+4. `curl -b 'XDEBUG_SESSION=PHPSTORM' http://localhost:8080/`.
+
+   The next `sapi_module.activate` calls `xdebug_dbgp_poll_pending()`,
+   which drains the queued commands and registers the new breakpoint.
+   PhpStorm pauses on line 5.
+
+   **Without the poll, the IDE's queued `breakpoint_set` is silently
+   ignored and the new breakpoint is never honored** — exactly the
+   symptom this PR fixes.
+
+### 5. Logs
+
+```bash
+docker exec $(docker ps -qf ancestor=php-debugger-frankenphp) \
+  tail -f /tmp/xdebug.log
+```
+
+Per debug request expect to see:
+
+```
+[Step Debug] INFO: Connecting to configured address/port: host.docker.internal:9003.
+[Step Debug] INFO: Connected to debugging client: ...
+... (DBGp protocol messages) ...
+Log closed at ...
+```
+
+A clean `Log closed` between requests confirms the per-request
+deactivate hook tore the session down before the next activate set up a
+fresh one.
+
+## Cleanup test
+
+`docker stop <container>` triggers PHP MSHUTDOWN, which calls
+`xdebug_frankenphp_mshutdown()` to restore the original
+`sapi_module.activate` / `deactivate` pointers. Clean exit (no segfault
+in the container logs) means the restore worked.
+
+## Troubleshooting
+
+| Symptom | Cause | Fix |
+|---|---|---|
+| `curl` returns nothing / 308 redirect to `https://` | FrankenPHP using its default Caddyfile, not ours | Confirm `tests/frankenphp/Caddyfile` was copied to `/etc/frankenphp/Caddyfile` (not `/etc/caddy/Caddyfile`) |
+| `Failed loading Zend extension 'php_debugger.so'` | `.so` not in versioned ext dir | Confirm `COPY --from=build /usr/local/lib/php/extensions/ ...` (whole dir, not flattened) |
+| `make: *** No rule to make target '/Users/.../xdebug.c'` during build | Host build artifacts (`Makefile`, `*.dep`) leaked into context | Repo-root `.dockerignore` should exclude `**/*.dep`, `**/*.lo`, `Makefile`, etc. — check it exists |
+| IDE warns about path mappings | Local file path ≠ container file path | Configure **Settings → PHP → Servers** as described above; bind-mount `-v "$PWD/tests/frankenphp/app:/app"` |
+| `Connecting to ... :0` in xdebug log | Tried to use `${VAR:default}` in PHP INI, which doesn't expand | Already fixed via `entrypoint.sh`; pass real `XDEBUG_CLIENT_HOST` / `_PORT` env vars at `docker run` |
+| `Creating socket ... error` in xdebug log | IDE not reachable from container | Linux: add `--add-host=host.docker.internal:host-gateway`. Or set `XDEBUG_CLIENT_HOST` to the host IP visible from the container. Verify the IDE is actually listening on the chosen port. |

--- a/tests/frankenphp/app/index.php
+++ b/tests/frankenphp/app/index.php
@@ -1,0 +1,10 @@
+<?php
+// Set a breakpoint in PhpStorm/VS Code on the line below — every request
+// served by the worker should pause here when XDEBUG_SESSION is sent.
+$pid = getmypid();
+$now = (new DateTimeImmutable())->format(DATE_ATOM);
+$worker_iteration = $GLOBALS['counter'] ?? 'n/a';
+
+header('Content-Type: text/plain');
+echo "pid={$pid} time={$now} iter={$worker_iteration}\n";
+echo "cookie: " . ($_COOKIE['XDEBUG_SESSION'] ?? '(none)') . "\n";

--- a/tests/frankenphp/app/worker.php
+++ b/tests/frankenphp/app/worker.php
@@ -1,0 +1,15 @@
+<?php
+// Minimal FrankenPHP worker. Each iteration of the loop is a separate HTTP
+// request handled by the SAME long-lived PHP process — the exact path we
+// need the SAPI activate/deactivate hooks for.
+ignore_user_abort(true);
+
+$counter = 0;
+$handler = static function () use (&$counter): void {
+    $counter++;
+    require __DIR__ . '/index.php';
+};
+
+while (frankenphp_handle_request($handler)) {
+    gc_collect_cycles();
+}

--- a/tests/frankenphp/entrypoint.sh
+++ b/tests/frankenphp/entrypoint.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+# Patch xdebug.client_host / xdebug.client_port from env vars before FrankenPHP
+# starts. PHP INI has no native ${VAR:default} fallback, so we do it here.
+set -e
+
+INI=/usr/local/etc/php/conf.d/zz-php-debugger.ini
+
+if [ -n "$XDEBUG_CLIENT_HOST" ]; then
+    sed -i "s|^xdebug.client_host=.*|xdebug.client_host=${XDEBUG_CLIENT_HOST}|" "$INI"
+fi
+if [ -n "$XDEBUG_CLIENT_PORT" ]; then
+    sed -i "s|^xdebug.client_port=.*|xdebug.client_port=${XDEBUG_CLIENT_PORT}|" "$INI"
+fi
+
+exec docker-php-entrypoint "$@"

--- a/xdebug.c
+++ b/xdebug.c
@@ -52,6 +52,7 @@
 # include "base/ctrl_socket.h"
 #endif
 #include "debugger/com.h"
+#include "debugger/frankenphp.h"
 #include "lib/usefulstuff.h"
 #include "lib/lib.h"
 #include "lib/llist.h"
@@ -554,6 +555,10 @@ PHP_MSHUTDOWN_FUNCTION(xdebug)
 		ts_free_id(xdebug_globals_id);
 #endif
 		return SUCCESS;
+	}
+
+	if (XDEBUG_MODE_IS(XDEBUG_MODE_STEP_DEBUG)) {
+		xdebug_frankenphp_mshutdown();
 	}
 
 	xdebug_library_mshutdown();


### PR DESCRIPTION
  Makes `php-debugger` work under FrankenPHP **worker mode**. In worker mode a single long-lived PHP process services many requests via
   `frankenphp_handle_request()`, so `MINIT`/`RINIT`/`RSHUTDOWN`/`MSHUTDOWN` only fire once per worker — not per request. This means
  the existing IDE handshake (done at `RINIT`), the trigger detection (also `RINIT`), and the per-request socket teardown              
  (`POST_ZEND_DEACTIVATE`) all only happen for the very first request the worker handles. Subsequent requests are not debuggable.
                                               
  This PR ports the approach from upstream Xdebug PR into php-debugger:
                                                                                                                                       
  - Detects the FrankenPHP SAPI at `MINIT` (`strcmp(sapi_module.name, "frankenphp") == 0`) and wraps `sapi_module.activate` /          
  `deactivate` to drive a per-request debugger lifecycle inside the worker loop.
  - On **activate**: resets `XG_DBG(detached/no_exec/breakpoints_allowed)` and `context.do_*` flags, scans raw                         
  `SG(request_info).cookie_data` and `query_string` for `XDEBUG_SESSION` / `XDEBUG_TRIGGER` / `PHP_DEBUGGER_*` (superglobals aren't    
  built yet at this point), then arms `do_connect_to_client` so the existing init path picks up where it would on a normal CGI/CLI
  request.                                                                                                                             
  - On **deactivate**: tears down any live DBGp session via `handler->remote_deinit` so the next request gets a fresh one.
  - Adds `xdebug_dbgp_poll_pending()` — a non-blocking `select()` loop on the DBGp socket — and calls it from the activate hook so     
  `breakpoint_set` / `breakpoint_remove` commands the IDE pushed while the worker was busy with another request actually get processed 
  before the next request runs. Continuation commands (`run`/`step_*`) are logged and ignored — they're only meaningful at a stop.     
  - `MSHUTDOWN` restores the original SAPI pointers via `xdebug_frankenphp_mshutdown()`.                                               
                                                                                                                                       
  For non-FrankenPHP SAPIs the new code is a strict no-op; the existing `RINIT`/`RSHUTDOWN` lifecycle is unchanged.                    
                                                                                                                                       
  Closes the equivalent of [dunglas/symfony-docker#868](https://github.com/dunglas/symfony-docker/issues/868) for php-debugger.        
                                                                                                        
                                                                                                                                       
  ## Test plan                                                                                                                         
                                                                                                                                       
  **Automated regression (already passing):**                                                                                          
                                               
  - [x] `phpize && ./configure --enable-php-debugger && make -j` — clean build, zero warnings on the new code (PHP 8.5 ZTS).           
  - [x] Full debugger test suite (`run-xdebug-tests.php tests/debugger/`): **240 passed, 0 new failures**. The single failure is
  `bug02090.phpt` (FFI/`__callStatic` segfault), which is pre-existing on `main` and unrelated to these hooks.                         
  - [x] Verified non-FrankenPHP SAPIs are unaffected: the hook is gated on `strcmp(sapi_module.name, "frankenphp") == 0`.
                                                                                                                                       
  **Manual FrankenPHP smoke test** (see `tests/frankenphp/README.md` for full instructions):                                           
                                                                                                                                       
  ```bash                                                                                                                              
  docker build -f tests/frankenphp/Dockerfile -t php-debugger-frankenphp .
  docker run --rm -p 8080:80 \                                                                                                         
    -v "$PWD/tests/frankenphp/app:/app" \                                                                                              
    php-debugger-frankenphp                                                                                                            
                                                                                                                                       
  With PhpStorm listening on 9003 and a path mapping configured (tests/frankenphp/app → /app):                                         
                                                                  
  - No trigger ⇒ no pause: curl http://localhost:8080/ returns immediately. Log shows Trigger value ... not found, so not activating.  
  - Trigger ⇒ pause: curl -b 'XDEBUG_SESSION=PHPSTORM' http://localhost:8080/ pauses on the breakpoint.
  - Same worker, multiple debug requests: pid= stays constant across requests (proves worker reuse), but the IDE pauses on every       
  request — proves the per-request sapi_module.activate reset.                                                                         
  - Breakpoint added between requests (the xdebug_dbgp_poll_pending test): pause once, move the breakpoint to a different line while   
  idle, send another debug request — the new breakpoint hits. Without the poll, the IDE's queued breakpoint_set is silently buffered   
  and the new breakpoint is never honored.                        
  - Clean shutdown: docker stop <container> exits cleanly — proves xdebug_frankenphp_mshutdown() correctly restored the original SAPI  
  pointers.                                                                                                                            
                                               
  Out of scope                                                                                                                         
                                                                  
  - Process-wide function-pointer overrides in src/base/base.c (set once in MINIT, safe in single-process worker).                     
  - pcntl_fork PID-tracking path in src/base/base.c — FrankenPHP uses threads, not forks.
  - Persistent (across-request) debug connections — we close per-request to match upstream Xdebug PR #1063 behavior. Can be revisited  
  later if IDE UX warrants it.   