### PR TITLE
refactor: remove all checks for debug mode

### DIFF
--- a/src/base/base.c
+++ b/src/base/base.c
@@ -437,10 +437,8 @@ static void xdebug_execute_user_code_begin(zend_execute_data *execute_data)
 	}
 
 	if (XG_BASE(in_execution) && XDEBUG_VECTOR_COUNT(XG_BASE(stack)) == 0 && ((EG(flags) & EG_FLAGS_IN_SHUTDOWN) == 0)) {
-		if (XDEBUG_MODE_IS(XDEBUG_MODE_STEP_DEBUG)) {
-			xdebug_debugger_set_program_name(op_array->filename);
-			xdebug_debug_init_if_requested_at_startup();
-		}
+		xdebug_debugger_set_program_name(op_array->filename);
+		xdebug_debug_init_if_requested_at_startup();
 
 		/* After first-call init, deactivate observer if no debugger connected */
 		if (!xdebug_is_debug_connection_active()) {
@@ -468,35 +466,28 @@ static void xdebug_execute_user_code_begin(zend_execute_data *execute_data)
 		fse->symbol_table = execute_data->symbol_table;
 	}
 
-	if (XDEBUG_MODE_IS(XDEBUG_MODE_STEP_DEBUG)) {
-		/* If we're in an eval, we need to create an ID for it. */
-		if (fse->function.type == XFUNC_EVAL) {
-			xdebug_debugger_register_eval(fse);
-		}
-
-		/* Check for entry breakpoints */
-		xdebug_debugger_handle_breakpoints(fse, XDEBUG_BREAKPOINT_TYPE_CALL|XDEBUG_BREAKPOINT_TYPE_EXTERNAL, NULL);
+	/* If we're in an eval, we need to create an ID for it. */
+	if (fse->function.type == XFUNC_EVAL) {
+		xdebug_debugger_register_eval(fse);
 	}
+
+	/* Check for entry breakpoints */
+	xdebug_debugger_handle_breakpoints(fse, XDEBUG_BREAKPOINT_TYPE_CALL|XDEBUG_BREAKPOINT_TYPE_EXTERNAL, NULL);
 
 }
 
 static void xdebug_execute_user_code_end(zend_execute_data *execute_data, zval *retval)
 {
 	zend_op_array        *op_array = &(execute_data->func->op_array);
-	function_stack_entry *fse;
+	function_stack_entry *fse = XDEBUG_VECTOR_TAIL(XG_BASE(stack));
+	zval *return_value = NULL;
 
-	fse = XDEBUG_VECTOR_TAIL(XG_BASE(stack));
-
-	if (XDEBUG_MODE_IS(XDEBUG_MODE_STEP_DEBUG)) {
-		zval *return_value = NULL;
-
-		if (!fse->is_trampoline && retval && !(op_array->fn_flags & ZEND_ACC_GENERATOR)) {
-			return_value = execute_data->return_value;
-		}
-
-		/* Check for return breakpoints */
-		xdebug_debugger_handle_breakpoints(fse, XDEBUG_BREAKPOINT_TYPE_RETURN|XDEBUG_BREAKPOINT_TYPE_EXTERNAL, return_value);
+	if (!fse->is_trampoline && retval && !(op_array->fn_flags & ZEND_ACC_GENERATOR)) {
+		return_value = execute_data->return_value;
 	}
+
+	/* Check for return breakpoints */
+	xdebug_debugger_handle_breakpoints(fse, XDEBUG_BREAKPOINT_TYPE_RETURN|XDEBUG_BREAKPOINT_TYPE_EXTERNAL, return_value);
 
 	if (XG_BASE(stack)) {
 		xdebug_vector_pop(XG_BASE(stack));
@@ -581,10 +572,8 @@ static void xdebug_execute_internal_begin(zend_execute_data *execute_data)
 		fse->symbol_table = execute_data->symbol_table;
 	}
 
-	if (XDEBUG_MODE_IS(XDEBUG_MODE_STEP_DEBUG)) {
-		/* Check for entry breakpoints */
-		xdebug_debugger_handle_breakpoints(fse, XDEBUG_BREAKPOINT_TYPE_CALL, NULL);
-	}
+	/* Check for entry breakpoints */
+	xdebug_debugger_handle_breakpoints(fse, XDEBUG_BREAKPOINT_TYPE_CALL, NULL);
 
 	/* Check for SOAP */
 	if (check_soap_call(fse, execute_data)) {
@@ -607,10 +596,8 @@ static void xdebug_execute_internal_end(zend_execute_data *execute_data, zval *r
 		zend_error_cb = fse->soap_error_cb;
 	}
 
-	if (XDEBUG_MODE_IS(XDEBUG_MODE_STEP_DEBUG)) {
-		/* Check for return breakpoints */
-		xdebug_debugger_handle_breakpoints(fse, XDEBUG_BREAKPOINT_TYPE_RETURN, return_value);
-	}
+	/* Check for return breakpoints */
+	xdebug_debugger_handle_breakpoints(fse, XDEBUG_BREAKPOINT_TYPE_RETURN, return_value);
 
 	if (XG_BASE(stack)) {
 		xdebug_vector_pop(XG_BASE(stack));
@@ -660,8 +647,8 @@ static void xdebug_execute_end(zend_execute_data *execute_data, zval *retval)
 
 static zend_observer_fcall_handlers xdebug_observer_init(zend_execute_data *execute_data)
 {
-	/* If debug mode is not enabled or observer is deactivated (no debugger connected), skip */
-	if (!XDEBUG_MODE_IS(XDEBUG_MODE_STEP_DEBUG) || !XG_BASE(observer_active)) {
+	/* If observer is deactivated (no debugger connected), skip */
+	if (!XG_BASE(observer_active)) {
 			return (zend_observer_fcall_handlers){NULL, NULL};
 	}
 	return (zend_observer_fcall_handlers){xdebug_execute_begin, xdebug_execute_end};
@@ -988,6 +975,9 @@ void xdebug_base_rinit(void)
 	/* Signal that we're in a request now */
 	XG_BASE(in_execution) = 1;
 
+	/* Observer starts active to allow first-call debug init check */
+	XG_BASE(observer_active) = 1;
+
 	/* filters */
 	XG_BASE(filter_type_stack)         = XDEBUG_FILTER_NONE;
 	XG_BASE(filters_stack)             = xdebug_llist_alloc(xdebug_llist_string_dtor);
@@ -1005,11 +995,7 @@ void xdebug_base_rinit_if_enabled(void)
 
 	/* Hack: We check for a soap header here, if that's existing, we don't use
 	 * Xdebug's error handler to keep soap fault from fucking up. */
-	if (
-		(XDEBUG_MODE_IS(XDEBUG_MODE_STEP_DEBUG))
-		&&
-		(zend_hash_str_find(Z_ARR(PG(http_globals)[TRACK_VARS_SERVER]), "HTTP_SOAPACTION", sizeof("HTTP_SOAPACTION") - 1) == NULL)
-	) {
+	if (zend_hash_str_find(Z_ARR(PG(http_globals)[TRACK_VARS_SERVER]), "HTTP_SOAPACTION", sizeof("HTTP_SOAPACTION") - 1) == NULL) {
 		xdebug_base_use_xdebug_error_cb();
 		xdebug_base_use_xdebug_throw_exception_hook();
 	}
@@ -1051,28 +1037,24 @@ void xdebug_base_rshutdown(void)
 #if PHP_VERSION_ID >= 80100
 static void xdebug_error_cb(int orig_type, zend_string *error_filename, const unsigned int error_lineno, zend_string *message)
 {
-	if (XDEBUG_MODE_IS(XDEBUG_MODE_STEP_DEBUG)) {
-		int type                        = orig_type & E_ALL;
-		char *error_type_str            = xdebug_error_type(type);
+	int type                        = orig_type & E_ALL;
+	char *error_type_str            = xdebug_error_type(type);
 
-		xdebug_debugger_error_cb(error_filename, error_lineno, type, error_type_str, ZSTR_VAL(message));
+	xdebug_debugger_error_cb(error_filename, error_lineno, type, error_type_str, ZSTR_VAL(message));
 
-		xdfree(error_type_str);
-	}
+	xdfree(error_type_str);
 }
 #else
 static void xdebug_error_cb(int orig_type, const char *error_filename, const unsigned int error_lineno, zend_string *message)
 {
-	if (XDEBUG_MODE_IS(XDEBUG_MODE_STEP_DEBUG)) {
-		int type                        = orig_type & E_ALL;
-		char *error_type_str            = xdebug_error_type(type);
-		zend_string *tmp_error_filename = zend_string_init(error_filename, strlen(error_filename), 0);
+	int type                        = orig_type & E_ALL;
+	char *error_type_str            = xdebug_error_type(type);
+	zend_string *tmp_error_filename = zend_string_init(error_filename, strlen(error_filename), 0);
 
-		xdebug_debugger_error_cb(tmp_error_filename, error_lineno, type, error_type_str, ZSTR_VAL(message));
+	xdebug_debugger_error_cb(tmp_error_filename, error_lineno, type, error_type_str, ZSTR_VAL(message));
 
-		zend_string_release(tmp_error_filename);
-		xdfree(error_type_str);
-	}
+	zend_string_release(tmp_error_filename);
+	xdfree(error_type_str);
 }
 #endif
 
@@ -1092,10 +1074,6 @@ static void xdebug_throw_exception_hook(zend_object *exception)
 	zend_class_entry *exception_ce;
 	char *code_str = NULL;
 	zval dummy;
-
-	if (!XDEBUG_MODE_IS(XDEBUG_MODE_STEP_DEBUG)) {
-		return;
-	}
 
 	if (!exception) {
 		return;
@@ -1133,9 +1111,7 @@ static void xdebug_throw_exception_hook(zend_object *exception)
 	convert_to_string_ex(file);
 	convert_to_long_ex(line);
 
-	if (XDEBUG_MODE_IS(XDEBUG_MODE_STEP_DEBUG)) {
-		xdebug_debugger_throw_exception_hook(exception, file, line, code, code_str, message);
-	}
+	xdebug_debugger_throw_exception_hook(exception, file, line, code, code_str, message);
 
 	/* Free code_str if necessary */
 	if (code_str) {

--- a/src/base/ctrl_socket.c
+++ b/src/base/ctrl_socket.c
@@ -218,18 +218,6 @@ CTRL_FUNC(pause)
 	xdebug_xml_add_text(pid, pid_str);
 	xdebug_xml_add_child(response, pid);
 
-	if (!XDEBUG_MODE_IS(XDEBUG_MODE_STEP_DEBUG)) {
-		xdebug_xml_node *error;
-
-		error = xdebug_xml_node_init("error");
-		xdebug_xml_add_attribute_ex(error, "code", xdebug_sprintf("%lu", XDEBUG_ERROR_STEP_DEBUG_MODE_NOT_ENABLED), 0, 1);
-		ADD_REASON_MESSAGE(XDEBUG_ERROR_STEP_DEBUG_MODE_NOT_ENABLED);
-		xdebug_xml_add_child(*retval, error);
-
-		xdebug_xml_add_child(*retval, response);
-		return;
-	}
-
 	if (!xdebug_is_debug_connection_active()) {
 		action = xdebug_xml_node_init("action");
 		xdebug_xml_add_text(action, xdstrdup("IDE Connection Signalled"));

--- a/src/debugger/com.c
+++ b/src/debugger/com.c
@@ -754,8 +754,6 @@ bool xdebug_should_ignore(void)
 
 void xdebug_debug_init_if_requested_on_connect_to_client(void)
 {
-	RETURN_IF_MODE_IS_NOT(XDEBUG_MODE_STEP_DEBUG);
-
 	if (xdebug_should_ignore()) {
 		return;
 	}
@@ -767,8 +765,6 @@ void xdebug_debug_init_if_requested_on_connect_to_client(void)
 
 void xdebug_debug_init_if_requested_on_error(void)
 {
-	RETURN_IF_MODE_IS_NOT(XDEBUG_MODE_STEP_DEBUG);
-
 	if (!xdebug_lib_start_upon_error()) {
 		return;
 	}
@@ -780,8 +776,6 @@ void xdebug_debug_init_if_requested_on_error(void)
 
 void xdebug_debug_init_if_requested_on_xdebug_break(void)
 {
-	RETURN_IF_MODE_IS_NOT(XDEBUG_MODE_STEP_DEBUG);
-
 	if (xdebug_is_debug_connection_active()) {
 		return;
 	}

--- a/src/debugger/debugger.c
+++ b/src/debugger/debugger.c
@@ -1121,8 +1121,6 @@ void xdebug_debugger_compile_file(zend_op_array *op_array)
 	zend_class_entry *class_entry;
 	xdebug_lines_list *file_function_lines_list;
 
-	RETURN_IF_MODE_IS_NOT(XDEBUG_MODE_STEP_DEBUG);
-
 	/* The breakable_lines_map can not be set if another extension compiles
 	 * scripts during RINIT */
 	if (!XG_DBG(breakable_lines_map)) {

--- a/src/lib/lib.c
+++ b/src/lib/lib.c
@@ -153,9 +153,6 @@ static int xdebug_lib_set_mode_item(const char *mode, int len)
 		xdebug_global_mode |= XDEBUG_MODE_STEP_DEBUG;
 		return 1;
 	}
-	if (strncmp(mode, "trace", len) == 0) {
-		return 1;
-	}
 
 	return 0;
 }
@@ -314,7 +311,6 @@ const char *xdebug_lib_mode_from_value(int mode)
 	switch (mode) {
 		case XDEBUG_MODE_STEP_DEBUG:
 			return "debug";
-			return "trace";
 		default:
 			return "?";
 	}

--- a/xdebug.c
+++ b/xdebug.c
@@ -379,9 +379,7 @@ static void php_xdebug_init_globals(zend_xdebug_globals *xg)
 	xdebug_init_library_globals(&xg->globals.library);
 	xdebug_init_base_globals(&xg->globals.base);
 
-	if (XDEBUG_MODE_IS(XDEBUG_MODE_STEP_DEBUG)) {
-		xdebug_init_debugger_globals(&xg->globals.debugger);
-	}
+	xdebug_init_debugger_globals(&xg->globals.debugger);
 }
 
 static void php_xdebug_shutdown_globals(zend_xdebug_globals *xg)
@@ -513,14 +511,10 @@ PHP_MINIT_FUNCTION(xdebug)
 	xdebug_library_minit();
 	xdebug_base_minit(INIT_FUNC_ARGS_PASSTHRU);
 
-	if (XDEBUG_MODE_IS(XDEBUG_MODE_STEP_DEBUG)) {
-		xdebug_debugger_minit();
-	}
+	xdebug_debugger_minit();
 
 	/* Overload the "include_or_eval" opcode if the mode is 'debug' or 'trace' */
-	if (XDEBUG_MODE_IS(XDEBUG_MODE_STEP_DEBUG)) {
-		xdebug_register_with_opcode_multi_handler(ZEND_INCLUDE_OR_EVAL, xdebug_include_or_eval_handler);
-	}
+	xdebug_register_with_opcode_multi_handler(ZEND_INCLUDE_OR_EVAL, xdebug_include_or_eval_handler);
 
 	/* Coverage must be last, as it has a catch all override for opcodes */
 
@@ -565,6 +559,9 @@ static void xdebug_init_auto_globals(void)
 
 PHP_RINIT_FUNCTION(xdebug)
 {
+	int debug_requested;
+	int connected;
+
 #if defined(ZTS) && defined(COMPILE_DL_XDEBUG)
 	ZEND_TSRMLS_CACHE_UPDATE();
 #endif
@@ -579,60 +576,53 @@ PHP_RINIT_FUNCTION(xdebug)
 
 	xdebug_library_rinit();
 
-	if (XDEBUG_MODE_IS(XDEBUG_MODE_STEP_DEBUG)) {
-		xdebug_debugger_rinit();
+	xdebug_debugger_rinit();
 
-		if (xdebug_debugger_bailout_if_no_exec_requested()) {
-			zend_bailout();
-		}
+	if (xdebug_debugger_bailout_if_no_exec_requested()) {
+		zend_bailout();
 	}
 
 	xdebug_init_auto_globals();
 
 	xdebug_base_rinit();
 
-	/* Early debug init: attempt connection at RINIT so observer_active is set
-	 * before any user code runs. This allows xdebug_observer_init to return
-	 * {NULL, NULL} for functions first-called when no debugger is connected. */
-	if (XDEBUG_MODE_IS(XDEBUG_MODE_STEP_DEBUG)) {
-		/* Check early if debugging could be requested this request.
-		 * Check if start_with_request=trigger and any trigger is present
-		 * or if start_with_request=yes.
-		 * If not, disable all heavy hooks for
-		 * near-zero overhead. The actual connection happens on first
-		 * function call if triggers are present. */
-		/* Check if debugging could be requested this request.
-		 * For trigger/default mode: check triggers, cookies, env vars.
-		 * For yes mode: always expect a connection.
-		 * For no mode: no debugging will happen.
-		 * Note: xdebug_break() can initiate connections without triggers,
-		 * but it handles re-enabling the observer itself. */
-		/* Respect start_with_request=no and XDEBUG_IGNORE */
-		int debug_requested = !xdebug_lib_never_start_with_request() && !xdebug_should_ignore() && (
-			xdebug_lib_start_with_request() ||
-			xdebug_lib_start_with_trigger(NULL) ||
-			xdebug_lib_start_upon_error() ||
-			getenv("XDEBUG_SESSION_START") != NULL ||
-			getenv("PHP_DEBUGGER_SESSION_START") != NULL
-		);
+	/* Check early if debugging could be requested this request.
+	 * Check if start_with_request=trigger and any trigger is present
+	 * or if start_with_request=yes.
+	 * If not, disable all heavy hooks for
+	 * near-zero overhead. The actual connection happens on first
+	 * function call if triggers are present. */
+	/* Check if debugging could be requested this request.
+	 * For trigger/default mode: check triggers, cookies, env vars.
+	 * For yes mode: always expect a connection.
+	 * For no mode: no debugging will happen.
+	 * Note: xdebug_break() can initiate connections without triggers,
+	 * but it handles re-enabling the observer itself. */
+	/* Respect start_with_request=no and XDEBUG_IGNORE */
+	debug_requested = !xdebug_lib_never_start_with_request() && !xdebug_should_ignore() && (
+		xdebug_lib_start_with_request() ||
+		xdebug_lib_start_with_trigger(NULL) ||
+		xdebug_lib_start_upon_error() ||
+		getenv("XDEBUG_SESSION_START") != NULL ||
+		getenv("PHP_DEBUGGER_SESSION_START") != NULL
+	);
 
-		int connected = false;
-		if (debug_requested) {
-			/* Debug session requested: check if a client is actually listening
-			 * before enabling expensive EXT_STMT opcodes. This avoids ~2x
-			 * overhead when triggers are present but no IDE is connected. */
-			if (xdebug_early_connect_to_client()) {
-				connected = true;
-			}
-			XG_BASE(early_connection) = 1;
+	connected = false;
+	if (debug_requested) {
+		/* Debug session requested: check if a client is actually listening
+		 * before enabling expensive EXT_STMT opcodes. This avoids ~2x
+		 * overhead when triggers are present but no IDE is connected. */
+		if (xdebug_early_connect_to_client()) {
+			connected = true;
 		}
-		if (!connected) {
-			if (!XINI_DBG(on_demand_debugging_enabled)) {
-				XG_BASE(observer_active) = false;
-				return SUCCESS;
-			}
-			XG_BASE(statement_handler_enabled) = false;
+		XG_BASE(early_connection) = 1;
+	}
+	if (!connected) {
+		if (!XINI_DBG(on_demand_debugging_enabled)) {
+			XG_BASE(observer_active) = false;
+			return SUCCESS;
 		}
+		XG_BASE(statement_handler_enabled) = false;
 	}
 	xdebug_base_rinit_if_enabled();
 
@@ -645,9 +635,7 @@ ZEND_MODULE_POST_ZEND_DEACTIVATE_D(xdebug)
 		return SUCCESS;
 	}
 
-	if (XDEBUG_MODE_IS(XDEBUG_MODE_STEP_DEBUG)) {
-		xdebug_debugger_post_deactivate();
-	}
+	xdebug_debugger_post_deactivate();
 
 	xdebug_base_post_deactivate();
 	xdebug_library_post_deactivate();
@@ -676,9 +664,7 @@ PHP_MINFO_FUNCTION(xdebug)
 		php_info_print_table_end();
 	}
 
-	if (XDEBUG_MODE_IS(XDEBUG_MODE_STEP_DEBUG)) {
-		xdebug_debugger_minfo();
-	}
+	xdebug_debugger_minfo();
 
 	DISPLAY_INI_ENTRIES();
 }
@@ -707,9 +693,7 @@ ZEND_DLEXPORT void xdebug_statement_call(zend_execute_data *frame)
 	op_array = &frame->func->op_array;
 	lineno = EG(current_execute_data)->opline->lineno;
 
-	if (XDEBUG_MODE_IS(XDEBUG_MODE_STEP_DEBUG)) {
-		xdebug_debugger_statement_call(op_array->filename, lineno);
-	}
+	xdebug_debugger_statement_call(op_array->filename, lineno);
 }
 
 ZEND_DLEXPORT int xdebug_zend_startup(zend_extension *extension)


### PR DESCRIPTION
Since we don't have any mode other than debug, we can remove all cases where we were checking if the mode was debug. The only other possible mode is off and all these places will not be called when the mode is off