### PR TITLE
Fix DBGP emulator handling only one command

### DIFF
--- a/tests/debugger/dbgp/dbgp-emulator.php
+++ b/tests/debugger/dbgp/dbgp-emulator.php
@@ -103,7 +103,7 @@ class DbgpEmulator extends DebugClient
 			$response = $this->doRead($conn, (string)$i);
 
 			// Check if the debugger has stopped
-			if ($response === null || feof($conn)) {
+			if (feof($conn)) {
 				$this->conversation[] = "Connection closed by debugger";
 				break;
 			}


### PR DESCRIPTION
When I created this emulator, I only tested it with a "commands" file which only contained one command but when I actually tried to use it with more commands I found out that only the first command was passed. Turns out that the `doRead()` function of the base class always returns null, independently of whether it correctly read some data or not, so the check for the return value always failed :facepalm: Turns out that this check is not really needed and checking if the connection has been closed is enough

The explanation is much longer than the fix! 😆 