### PR TITLE
feature: optimize the case where we are connected but not actively used

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -101,7 +101,7 @@ jobs:
                     sudo cp ./.github/benchmark-files/php-debugger-on-demand-benchmark.ini /etc/php/${{ matrix.php }}/cli/conf.d
                     sudo cp ./.github/benchmark-files/php-debugger-on-demand-benchmark.ini /etc/php/${{ matrix.php }}/cgi/conf.d
 
-            -   name: Copy on-demand php_debugger ini file
+            -   name: Copy connected php_debugger ini file
                 if: matrix.php_debugger_mode == 'debug-connected'
                 run: |
                     sudo cp ./.github/benchmark-files/php-debugger-connected-benchmark.ini /etc/php/${{ matrix.php }}/cli/conf.d

--- a/src/base/base.c
+++ b/src/base/base.c
@@ -429,7 +429,7 @@ static void add_stack_frame_recursively(zend_execute_data *execute_data)
 }
 
 /*
- * This function rebuilds the stack when we the debugger is activated after
+ * This function rebuilds the stack when the debugger is activated after
  * being previously deactivated. This rebuild deliberately does not fire entry side-effects,
  * like recording eval functions or checking function entry breakpoints
  */

--- a/src/base/base.c
+++ b/src/base/base.c
@@ -528,6 +528,11 @@ static bool should_run_user_handler(zend_execute_data *execute_data)
 		return false;
 	}
 
+	if (execute_data->func->type == ZEND_EVAL_CODE)
+	{
+		return false;
+	}
+
 	return true;
 }
 

--- a/src/base/base.c
+++ b/src/base/base.c
@@ -428,6 +428,11 @@ static void add_stack_frame_recursively(zend_execute_data *execute_data)
 	}
 }
 
+/*
+ * This function rebuilds the stack when we the debugger is activated after
+ * being previously deactivated. This rebuild deliberately does not fire entry side-effects,
+ * like recording eval functions or checking function entry breakpoints
+ */
 void xdebug_rebuild_stack(void)
 {
 	xdebug_vector_empty(XG_BASE(stack));

--- a/src/base/base.c
+++ b/src/base/base.c
@@ -408,6 +408,33 @@ function_stack_entry *xdebug_add_stack_frame(zend_execute_data *zdata, zend_op_a
 	return tmp;
 }
 
+static void add_stack_frame_recursively(zend_execute_data *execute_data)
+{
+	zend_op_array *op_array;
+	int type;
+	function_stack_entry *fse;
+
+	if (execute_data->prev_execute_data) {
+		add_stack_frame_recursively(execute_data->prev_execute_data);
+	}
+	if (execute_data->func) {
+		op_array = &(execute_data->func->op_array);
+		type = ZEND_USER_CODE(execute_data->func->type) ? XDEBUG_USER_DEFINED : XDEBUG_BUILT_IN;
+		fse = xdebug_add_stack_frame(execute_data, op_array, type);
+		fse->execute_data = execute_data->prev_execute_data;
+		if (ZEND_CALL_INFO(execute_data) & ZEND_CALL_HAS_SYMBOL_TABLE) {
+			fse->symbol_table = execute_data->symbol_table;
+		}
+	}
+}
+
+void xdebug_rebuild_stack(void)
+{
+	xdebug_vector_empty(XG_BASE(stack));
+
+	add_stack_frame_recursively(EG(current_execute_data));
+}
+
 /** Function interceptors and dispatchers to modules ***********************/
 
 static void xdebug_execute_user_code_begin(zend_execute_data *execute_data)

--- a/src/base/base.h
+++ b/src/base/base.h
@@ -33,4 +33,6 @@ void xdebug_func_dtor(xdebug_func *elem);
 void xdebug_build_fname(xdebug_func *tmp, zend_execute_data *edata);
 
 void xdebug_print_info(void);
+
+void xdebug_rebuild_stack(void);
 #endif // __XDEBUG_BASE_H__

--- a/src/base/ctrl_socket.c
+++ b/src/base/ctrl_socket.c
@@ -34,6 +34,7 @@
 #include "lib/cmd_parser.h"
 #include "lib/log.h"
 #include "lib/xml.h"
+#include "base/base.h"
 
 #if WIN32
 #include <windows.h>
@@ -223,14 +224,20 @@ CTRL_FUNC(pause)
 		xdebug_xml_add_text(action, xdstrdup("IDE Connection Signalled"));
 
 		XG_DBG(context).do_connect_to_client = 1;
-
-        XG_BASE(statement_handler_enabled) = true;
 	} else {
 		action = xdebug_xml_node_init("action");
 		xdebug_xml_add_text(action, xdstrdup("Breakpoint Signalled"));
 
 		XG_DBG(context).do_break = 1;
 	}
+
+	if (!XG_BASE(observer_active)) {
+		xdebug_rebuild_stack();
+	}
+
+	XG_BASE(statement_handler_enabled) = true;
+	XG_BASE(observer_active) = true;
+
 	xdebug_xml_add_child(response, action);
 	xdebug_xml_add_child(*retval, response);
 }

--- a/src/debugger/com.c
+++ b/src/debugger/com.c
@@ -661,7 +661,9 @@ static void xdebug_init_debugger(void)
 		xdebug_log_ex(XLOG_CHAN_DEBUG, XLOG_ERR, "NOPERM", "No permission connecting to debugging client (%s). This could be SELinux related.", connection_attempts->d);
 	}
 
-	XG_BASE(statement_handler_enabled) = XG_DBG(remote_connection_enabled);
+	if (XINI_DBG(on_demand_debugging_enabled)) {
+		XG_BASE(statement_handler_enabled) = XG_DBG(remote_connection_enabled);
+	}
 
 	xdebug_str_free(connection_attempts);
 }

--- a/src/debugger/debugger.c
+++ b/src/debugger/debugger.c
@@ -1269,6 +1269,7 @@ PHP_FUNCTION(xdebug_connect_to_client)
 
 	if (!XG_BASE(observer_active)) {
 		xdebug_rebuild_stack();
+		xdebug_vector_pop(XG_BASE(stack));
 	}
 
 	XG_BASE(statement_handler_enabled) = true;

--- a/src/debugger/debugger.c
+++ b/src/debugger/debugger.c
@@ -1246,7 +1246,8 @@ PHP_FUNCTION(xdebug_break)
 	XG_DBG(context).do_break = 1;
 	XG_DBG(context).pending_breakpoint = NULL;
 
-    XG_BASE(statement_handler_enabled) = true;
+	XG_BASE(statement_handler_enabled) = true;
+	XG_BASE(observer_active) = true;
 
 	RETURN_TRUE;
 }
@@ -1266,7 +1267,12 @@ PHP_FUNCTION(xdebug_connect_to_client)
 
 	XG_DBG(context).do_connect_to_client = 1;
 
-    XG_BASE(statement_handler_enabled) = true;
+	if (!XG_BASE(observer_active)) {
+		xdebug_rebuild_stack();
+	}
+
+	XG_BASE(statement_handler_enabled) = true;
+	XG_BASE(observer_active) = true;
 
 	RETURN_TRUE;
 }

--- a/src/debugger/debugger.c
+++ b/src/debugger/debugger.c
@@ -19,6 +19,7 @@
 #include "ext/standard/info.h"
 #include "zend_exceptions.h"
 
+#include "base/base.h"
 #include "debugger_private.h"
 #include "frankenphp.h"
 #include "lib/log.h"
@@ -1231,6 +1232,11 @@ PHP_FUNCTION(xdebug_break)
 		RETURN_FALSE;
 	}
 
+	if (!XG_BASE(observer_active)) {
+		xdebug_rebuild_stack();
+		xdebug_vector_pop(XG_BASE(stack));
+	}
+
 	xdebug_debug_init_if_requested_on_xdebug_break();
 
 	if (!xdebug_is_debug_connection_active()) {
@@ -1239,6 +1245,8 @@ PHP_FUNCTION(xdebug_break)
 
 	XG_DBG(context).do_break = 1;
 	XG_DBG(context).pending_breakpoint = NULL;
+
+    XG_BASE(statement_handler_enabled) = true;
 
 	RETURN_TRUE;
 }
@@ -1281,6 +1289,10 @@ PHP_FUNCTION(xdebug_notify)
 
 	if (zend_parse_parameters(ZEND_NUM_ARGS(), "z", &data) == FAILURE) {
 		return;
+	}
+
+	if (!XG_BASE(observer_active)) {
+		xdebug_rebuild_stack();
 	}
 
 	fse = xdebug_get_stack_frame(0);

--- a/src/debugger/handler_dbgp.c
+++ b/src/debugger/handler_dbgp.c
@@ -2493,6 +2493,23 @@ static int xdebug_dbgp_cmdloop(xdebug_con *context, int bail)
 		free(option);
 	} while (0 == ret);
 
+	if (!XG_DBG(context).do_connect_to_client &&
+		!XG_DBG(context).do_break &&
+		!XG_DBG(context).do_finish &&
+		!XG_DBG(context).do_next &&
+		!XG_DBG(context).do_step &&
+		!XG_DBG(context).send_notifications &&
+		!xdebug_lib_start_upon_error() &&
+		(!XG_DBG(context).line_breakpoints || XG_DBG(context).line_breakpoints->size == 0) &&
+		(!XG_DBG(context).exception_breakpoints || XG_DBG(context).exception_breakpoints->size == 0) &&
+		(!XG_DBG(context).function_breakpoints || XG_DBG(context).function_breakpoints->size == 0)
+	) {
+		if (!XINI_DBG(on_demand_debugging_enabled)) {
+			XG_BASE(observer_active) = false;
+		}
+		XG_BASE(statement_handler_enabled) = false;
+	}
+
 	if (bail && XG_DBG(status) == DBGP_STATUS_STOPPED) {
 		_zend_bailout((char*)__FILE__, __LINE__);
 	}

--- a/src/lib/vector.h
+++ b/src/lib/vector.h
@@ -125,4 +125,11 @@ static inline xdebug_vector *xdebug_vector_clone(xdebug_vector *v)
 	return tmp;
 }
 
+static inline void xdebug_vector_empty(xdebug_vector *v)
+{
+	while (XDEBUG_VECTOR_COUNT(v)) {
+		xdebug_vector_pop(v);
+	}
+}
+
 #endif /* __XDEBUG_VECTOR_H__ */

--- a/src/lib/vector.h
+++ b/src/lib/vector.h
@@ -104,11 +104,16 @@ static inline xdebug_vector *xdebug_vector_alloc(size_t element_size, xdebug_vec
 	return tmp;
 }
 
-static inline void xdebug_vector_destroy(xdebug_vector *v)
+static inline void xdebug_vector_empty(xdebug_vector *v)
 {
 	while (XDEBUG_VECTOR_COUNT(v)) {
 		xdebug_vector_pop(v);
 	}
+}
+
+static inline void xdebug_vector_destroy(xdebug_vector *v)
+{
+	xdebug_vector_empty(v);
 	xdfree(v->data);
 	xdfree(v);
 }
@@ -123,13 +128,6 @@ static inline xdebug_vector *xdebug_vector_clone(xdebug_vector *v)
 	memcpy(tmp->data, v->data, v->capacity * v->element_size);
 
 	return tmp;
-}
-
-static inline void xdebug_vector_empty(xdebug_vector *v)
-{
-	while (XDEBUG_VECTOR_COUNT(v)) {
-		xdebug_vector_pop(v);
-	}
 }
 
 #endif /* __XDEBUG_VECTOR_H__ */

--- a/tests/debugger/bug02025.phpt
+++ b/tests/debugger/bug02025.phpt
@@ -5,6 +5,9 @@ Test for bug #2025: Anonymous classes which extend are not detected as anonymous
 require __DIR__ . '/../utils.inc';
 check_reqs('dbgp');
 ?>
+--XFAIL--
+Will fail until this is merged with the branch which adds the xdebug_execute_ex function back as it needs this
+function to be able to get the name of executed evals
 --FILE--
 <?php
 require 'dbgp/dbgpclient.php';

--- a/tests/debugger/bug02025.phpt
+++ b/tests/debugger/bug02025.phpt
@@ -5,9 +5,6 @@ Test for bug #2025: Anonymous classes which extend are not detected as anonymous
 require __DIR__ . '/../utils.inc';
 check_reqs('dbgp');
 ?>
---XFAIL--
-Will fail until this is merged with the branch which adds the xdebug_execute_ex function back as it needs this
-function to be able to get the name of executed evals
 --FILE--
 <?php
 require 'dbgp/dbgpclient.php';

--- a/tests/debugger/rebuild-stack-after-xdebug-break.inc
+++ b/tests/debugger/rebuild-stack-after-xdebug-break.inc
@@ -1,0 +1,12 @@
+<?php
+function inner_function() {
+    return 42;
+}
+
+function outer_function() {
+    xdebug_break();
+    $result = inner_function();
+    return $result;
+}
+
+outer_function();

--- a/tests/debugger/rebuild-stack-after-xdebug-break.phpt
+++ b/tests/debugger/rebuild-stack-after-xdebug-break.phpt
@@ -1,0 +1,47 @@
+--TEST--
+Stack is correctly rebuilt after xdebug_break() with on_demand_debugging_enabled=0
+--SKIPIF--
+<?php
+require __DIR__ . '/../utils.inc';
+check_reqs('dbgp');
+?>
+--FILE--
+<?php
+require 'dbgp/dbgpclient.php';
+
+$filename = dirname(__FILE__) . '/rebuild-stack-after-xdebug-break.inc';
+
+$commands = array(
+	'run',
+	'step_into',
+	'stack_get',
+	'detach',
+);
+
+$settings = [
+	'xdebug.mode' => 'debug',
+	'xdebug.start_with_request' => 'yes',
+	'xdebug.on_demand_debugging_enabled' => 0
+];
+
+dbgpRunFile( $filename, $commands, $settings );
+?>
+--EXPECTF--
+<?xml version="1.0" encoding="iso-8859-1"?>
+<init xmlns="urn:debugger_protocol_v1" xmlns:xdebug="https://xdebug.org/dbgp/xdebug" fileuri="file://rebuild-stack-after-xdebug-break.inc" language="PHP" xdebug:language_version="" protocol_version="1.0" appid=""><engine version=""><![CDATA[PHP Debugger]]></engine><author><![CDATA[Derick Rethans]]></author><url><![CDATA[https://xdebug.org]]></url><copyright><![CDATA[Copyright (c) 2002-2099 by Derick Rethans]]></copyright></init>
+
+-> run -i 1
+<?xml version="1.0" encoding="iso-8859-1"?>
+<response xmlns="urn:debugger_protocol_v1" xmlns:xdebug="https://xdebug.org/dbgp/xdebug" command="run" transaction_id="1" status="break" reason="ok"><xdebug:message filename="file://rebuild-stack-after-xdebug-break.inc" lineno="8"></xdebug:message></response>
+
+-> step_into -i 2
+<?xml version="1.0" encoding="iso-8859-1"?>
+<response xmlns="urn:debugger_protocol_v1" xmlns:xdebug="https://xdebug.org/dbgp/xdebug" command="step_into" transaction_id="2" status="break" reason="ok"><xdebug:message filename="file://rebuild-stack-after-xdebug-break.inc" lineno="3"></xdebug:message></response>
+
+-> stack_get -i 3
+<?xml version="1.0" encoding="iso-8859-1"?>
+<response xmlns="urn:debugger_protocol_v1" xmlns:xdebug="https://xdebug.org/dbgp/xdebug" command="stack_get" transaction_id="3"><stack where="inner_function" level="0" type="file" filename="file://rebuild-stack-after-xdebug-break.inc" lineno="3"></stack><stack where="outer_function" level="1" type="file" filename="file://rebuild-stack-after-xdebug-break.inc" lineno="8"></stack><stack where="{main}" level="2" type="file" filename="file://rebuild-stack-after-xdebug-break.inc" lineno="12"></stack></response>
+
+-> detach -i 4
+<?xml version="1.0" encoding="iso-8859-1"?>
+<response xmlns="urn:debugger_protocol_v1" xmlns:xdebug="https://xdebug.org/dbgp/xdebug" command="detach" transaction_id="4" status="stopping" reason="ok"></response>

--- a/tests/debugger/rebuild-stack-after-xdebug-break.phpt
+++ b/tests/debugger/rebuild-stack-after-xdebug-break.phpt
@@ -13,7 +13,10 @@ $filename = dirname(__FILE__) . '/rebuild-stack-after-xdebug-break.inc';
 
 $commands = array(
 	'run',
+	'stack_get',
 	'step_into',
+	'stack_get',
+	'step_out',
 	'stack_get',
 	'detach',
 );
@@ -34,14 +37,26 @@ dbgpRunFile( $filename, $commands, $settings );
 <?xml version="1.0" encoding="iso-8859-1"?>
 <response xmlns="urn:debugger_protocol_v1" xmlns:xdebug="https://xdebug.org/dbgp/xdebug" command="run" transaction_id="1" status="break" reason="ok"><xdebug:message filename="file://rebuild-stack-after-xdebug-break.inc" lineno="8"></xdebug:message></response>
 
--> step_into -i 2
+-> stack_get -i 2
 <?xml version="1.0" encoding="iso-8859-1"?>
-<response xmlns="urn:debugger_protocol_v1" xmlns:xdebug="https://xdebug.org/dbgp/xdebug" command="step_into" transaction_id="2" status="break" reason="ok"><xdebug:message filename="file://rebuild-stack-after-xdebug-break.inc" lineno="3"></xdebug:message></response>
+<response xmlns="urn:debugger_protocol_v1" xmlns:xdebug="https://xdebug.org/dbgp/xdebug" command="stack_get" transaction_id="2"><stack where="outer_function" level="0" type="file" filename="file://rebuild-stack-after-xdebug-break.inc" lineno="8"></stack><stack where="{main}" level="1" type="file" filename="file://rebuild-stack-after-xdebug-break.inc" lineno="12"></stack></response>
 
--> stack_get -i 3
+-> step_into -i 3
 <?xml version="1.0" encoding="iso-8859-1"?>
-<response xmlns="urn:debugger_protocol_v1" xmlns:xdebug="https://xdebug.org/dbgp/xdebug" command="stack_get" transaction_id="3"><stack where="inner_function" level="0" type="file" filename="file://rebuild-stack-after-xdebug-break.inc" lineno="3"></stack><stack where="outer_function" level="1" type="file" filename="file://rebuild-stack-after-xdebug-break.inc" lineno="8"></stack><stack where="{main}" level="2" type="file" filename="file://rebuild-stack-after-xdebug-break.inc" lineno="12"></stack></response>
+<response xmlns="urn:debugger_protocol_v1" xmlns:xdebug="https://xdebug.org/dbgp/xdebug" command="step_into" transaction_id="3" status="break" reason="ok"><xdebug:message filename="file://rebuild-stack-after-xdebug-break.inc" lineno="3"></xdebug:message></response>
 
--> detach -i 4
+-> stack_get -i 4
 <?xml version="1.0" encoding="iso-8859-1"?>
-<response xmlns="urn:debugger_protocol_v1" xmlns:xdebug="https://xdebug.org/dbgp/xdebug" command="detach" transaction_id="4" status="stopping" reason="ok"></response>
+<response xmlns="urn:debugger_protocol_v1" xmlns:xdebug="https://xdebug.org/dbgp/xdebug" command="stack_get" transaction_id="4"><stack where="inner_function" level="0" type="file" filename="file://rebuild-stack-after-xdebug-break.inc" lineno="3"></stack><stack where="outer_function" level="1" type="file" filename="file://rebuild-stack-after-xdebug-break.inc" lineno="8"></stack><stack where="{main}" level="2" type="file" filename="file://rebuild-stack-after-xdebug-break.inc" lineno="12"></stack></response>
+
+-> step_out -i 5
+<?xml version="1.0" encoding="iso-8859-1"?>
+<response xmlns="urn:debugger_protocol_v1" xmlns:xdebug="https://xdebug.org/dbgp/xdebug" command="step_out" transaction_id="5" status="break" reason="ok"><xdebug:message filename="file://rebuild-stack-after-xdebug-break.inc" lineno="9"></xdebug:message></response>
+
+-> stack_get -i 6
+<?xml version="1.0" encoding="iso-8859-1"?>
+<response xmlns="urn:debugger_protocol_v1" xmlns:xdebug="https://xdebug.org/dbgp/xdebug" command="stack_get" transaction_id="6"><stack where="outer_function" level="0" type="file" filename="file://rebuild-stack-after-xdebug-break.inc" lineno="9"></stack><stack where="{main}" level="1" type="file" filename="file://rebuild-stack-after-xdebug-break.inc" lineno="12"></stack></response>
+
+-> detach -i 7
+<?xml version="1.0" encoding="iso-8859-1"?>
+<response xmlns="urn:debugger_protocol_v1" xmlns:xdebug="https://xdebug.org/dbgp/xdebug" command="detach" transaction_id="7" status="stopping" reason="ok"></response>


### PR DESCRIPTION
In this PR we optimise the case where the debugger connected to a debugging client but the debugging client did not actually provide any real interaction with the code: no breakpoints, no stepping into code, no start upon errors or exceptions, just connect and run the code. This is a usual situation when you have been debugging some code and you finish your debugging session but forget to stop listening on the IDE. Before this change, the debugger would be fully activated and your code would run slowly.

The way this works is that if we detect that after the initial connection no actual debugging actions have been set up, we can disable most of the debugger functionality as in the case when the debugger never connected. The code will not be as performant as in this second case because there are some things like the compiler flag to execute the statement handler which cannot be disabled at this stage.

Nevertheless, the performance of the code for this case is much better than before, it represents an improvement of close to 80% over the previous code, see the results of the performance run: https://github.com/php-debugger/php-debugger/actions/runs/25061631425

In most cases we end up with an overhead of 30%-50%, perhaps slightly noticeable but way better than what we had before.