### PR TITLE
refactor: remove all code for PHP versions lower than 8.2

### DIFF
--- a/src/base/base.c
+++ b/src/base/base.c
@@ -19,17 +19,13 @@
 #include "php_globals.h"
 #include "zend_closures.h"
 #include "zend_exceptions.h"
-#if PHP_VERSION_ID >= 80200
 # include "zend_attributes.h"
-#endif
 
 #include "zend_interfaces.h"
 
-#if PHP_VERSION_ID >= 80100
 # include "base_private.h"
 # include "Zend/zend_fibers.h"
 # include "Zend/zend_observer.h"
-#endif
 
 #include "php_xdebug.h"
 #include "php_xdebug_arginfo.h"
@@ -53,15 +49,9 @@ zif_handler orig_pcntl_exec_func = NULL;
 zif_handler orig_pcntl_fork_func = NULL;
 zif_handler orig_exit_func = NULL;
 
-#if PHP_VERSION_ID >= 80100
 void (*xdebug_old_error_cb)(int type, zend_string *error_filename, const uint32_t error_lineno, zend_string *message);
 void (*xdebug_new_error_cb)(int type, zend_string *error_filename, const uint32_t error_lineno, zend_string *message);
 static void xdebug_error_cb(int orig_type, zend_string *error_filename, const uint32_t error_lineno, zend_string *message);
-#else
-void (*xdebug_old_error_cb)(int type, const char *error_filename, const uint32_t error_lineno, zend_string *message);
-void (*xdebug_new_error_cb)(int type, const char *error_filename, const uint32_t error_lineno, zend_string *message);
-static void xdebug_error_cb(int orig_type, const char *error_filename, const uint32_t error_lineno, zend_string *message);
-#endif
 
 /* execution redirection functions */
 zend_op_array* (*old_compile_file)(zend_file_handle* file_handle, int type);
@@ -1023,7 +1013,6 @@ void xdebug_base_rshutdown(void)
 }
 
 /* Error callback for formatting stack traces */
-#if PHP_VERSION_ID >= 80100
 static void xdebug_error_cb(int orig_type, zend_string *error_filename, const unsigned int error_lineno, zend_string *message)
 {
 	int type                        = orig_type & E_ALL;
@@ -1035,19 +1024,6 @@ static void xdebug_error_cb(int orig_type, zend_string *error_filename, const un
 
 	xdebug_old_error_cb(orig_type, error_filename, error_lineno, message);
 }
-#else
-static void xdebug_error_cb(int orig_type, const char *error_filename, const unsigned int error_lineno, zend_string *message)
-{
-	int type                        = orig_type & E_ALL;
-	char *error_type_str            = xdebug_error_type(type);
-	zend_string *tmp_error_filename = zend_string_init(error_filename, strlen(error_filename), 0);
-
-	xdebug_debugger_error_cb(tmp_error_filename, error_lineno, type, error_type_str, ZSTR_VAL(message));
-
-	zend_string_release(tmp_error_filename);
-	xdfree(error_type_str);
-}
-#endif
 
 void xdebug_base_use_original_error_cb(void)
 {
@@ -1074,11 +1050,9 @@ static void xdebug_throw_exception_hook(zend_object *exception)
 		return;
 	}
 
-#if PHP_VERSION_ID >= 80100
 	if (zend_is_graceful_exit(exception)) {
 		return;
 	}
-#endif
 
 	exception_ce = exception->ce;
 

--- a/src/base/base_globals.h
+++ b/src/base/base_globals.h
@@ -41,9 +41,7 @@ typedef struct _xdebug_nanotime_context {
 
 typedef struct _xdebug_base_globals_t {
 	xdebug_vector *stack;
-#if PHP_VERSION_ID >= 80100
 	xdebug_hash   *fiber_stacks;
-#endif
 	xdebug_nanotime_context nanotime_context;
 	uint64_t      start_nanotime;
 	unsigned int  working_tsc_clock; /* -1 = unknown, 0 = not available, 1 = available */

--- a/src/debugger/debugger.c
+++ b/src/debugger/debugger.c
@@ -1041,7 +1041,6 @@ static void add_function_to_lines_list(xdebug_lines_list *lines_list, zend_op_ar
 	lines_list->functions[lines_list->count] = map_item;
 	lines_list->count++;
 
-#if PHP_VERSION_ID >= 80100
 	if (opa->num_dynamic_func_defs) {
 		uint32_t i;
 
@@ -1049,7 +1048,6 @@ static void add_function_to_lines_list(xdebug_lines_list *lines_list, zend_op_ar
 			add_function_to_lines_list(lines_list, opa->dynamic_func_defs[i]);
 		}
 	}
-#endif
 }
 /* }}} */
 

--- a/src/lib/lib.h
+++ b/src/lib/lib.h
@@ -48,9 +48,7 @@ typedef struct xdebug_var_name {
 #define XFUNC_REQUIRE        0x13
 #define XFUNC_REQUIRE_ONCE   0x14
 #define XFUNC_MAIN           0x15
-#if PHP_VERSION_ID >= 80100
-# define XFUNC_FIBER         0x16
-#endif
+#define XFUNC_FIBER          0x16
 
 #define XFUNC_ZEND_PASS      0x20
 
@@ -140,11 +138,7 @@ typedef struct _function_stack_entry {
 
 	/* misc properties */
 	zend_op_array *op_array;
-#if PHP_VERSION_ID >= 80100
 	void           (*soap_error_cb)(int type, zend_string *error_filename, const uint32_t error_lineno, zend_string *message);
-#else
-	void           (*soap_error_cb)(int type, const char *error_filename, const uint32_t error_lineno, zend_string *message);
-#endif
 } function_stack_entry;
 
 function_stack_entry *xdebug_get_stack_frame(int nr);

--- a/src/lib/str.c
+++ b/src/lib/str.c
@@ -114,7 +114,6 @@ void xdebug_str_add_uint64(xdebug_str *xs, uint64_t num)
 	xdebug_str_internal_addl(xs, pos, &buffer[20] - pos, 0);
 }
 
-#if PHP_VERSION_ID >= 80200
 void xdebug_str_add_va_fmt(xdebug_str *xs, const char *fmt, va_list argv)
 {
 	int size;
@@ -146,22 +145,6 @@ void xdebug_str_add_va_fmt(xdebug_str *xs, const char *fmt, va_list argv)
 
 	assert(0);
 }
-#else
-void xdebug_str_add_va_fmt(xdebug_str *xs, const char *fmt, va_list argv)
-{
-	smart_str buf = {0};
-
-	php_printf_to_smart_str(&buf, fmt, argv);
-
-	if (!buf.s) {
-		return;
-	}
-
-	xdebug_str_add_zstr(xs, buf.s);
-
-	smart_str_free(&buf);
-}
-#endif
 
 void xdebug_str_add_fmt(xdebug_str *xs, const char *fmt, ...)
 {

--- a/src/lib/usefulstuff.c
+++ b/src/lib/usefulstuff.c
@@ -41,11 +41,7 @@
 #include "usefulstuff.h"
 #include "log.h"
 
-#if PHP_VERSION_ID >= 80200
 # include "ext/random/php_random.h"
-#else
-# include "ext/standard/php_lcg.h"
-#endif
 #include "ext/standard/flock_compat.h"
 #include "main/php_ini.h"
 

--- a/src/lib/var.c
+++ b/src/lib/var.c
@@ -916,11 +916,9 @@ xdebug_str* xdebug_get_property_type(zval* object, zval *val)
 		zend_string *type_info = zend_type_to_string(info->type);
 		type_str = xdebug_str_new();
 
-# if PHP_VERSION_ID >= 80100
 		if (info->flags & ZEND_ACC_READONLY) {
 			xdebug_str_add_literal(type_str, "readonly ");
 		}
-# endif
 
 		xdebug_str_add_zstr(type_str, type_info);
 		zend_string_release(type_info);
@@ -1212,11 +1210,9 @@ char* xdebug_show_fname(xdebug_func f, int flags)
 			return xdstrdup("{zend_pass}");
 			break;
 
-#if PHP_VERSION_ID >= 80100
 		case XFUNC_FIBER:
 			return xdebug_sprintf("%s", ZSTR_VAL(f.function));
 			break;
-#endif
 
 		default:
 			return xdstrdup("{unknown}");

--- a/src/lib/var_export_html.c
+++ b/src/lib/var_export_html.c
@@ -17,15 +17,13 @@
 #include "var_export_html.h"
 #include "lib_private.h"
 #include "Zend/zend_closures.h"
-#if PHP_VERSION_ID >= 80100
-# if !defined(_MSC_VER)
-#   pragma GCC diagnostic push
-#   pragma GCC diagnostic ignored "-Wdeclaration-after-statement"
-# endif
-# include "zend_enum.h"
-# if !defined(_MSC_VER)
-#   pragma GCC diagnostic pop
-# endif
+#if !defined(_MSC_VER)
+#  pragma GCC diagnostic push
+#  pragma GCC diagnostic ignored "-Wdeclaration-after-statement"
+#endif
+#include "zend_enum.h"
+#if !defined(_MSC_VER)
+#  pragma GCC diagnostic pop
 #endif
 
 ZEND_EXTERN_MODULE_GLOBALS(xdebug)

--- a/src/lib/var_export_line.c
+++ b/src/lib/var_export_line.c
@@ -17,15 +17,13 @@
 #include "lib/php-header.h"
 #include "ext/standard/php_string.h"
 #include "Zend/zend_closures.h"
-#if PHP_VERSION_ID >= 80100
-# if !defined(_MSC_VER)
-#   pragma GCC diagnostic push
-#   pragma GCC diagnostic ignored "-Wdeclaration-after-statement"
-# endif
-# include "zend_enum.h"
-# if !defined(_MSC_VER)
-#   pragma GCC diagnostic pop
-# endif
+#if !defined(_MSC_VER)
+#  pragma GCC diagnostic push
+#  pragma GCC diagnostic ignored "-Wdeclaration-after-statement"
+#endif
+#include "zend_enum.h"
+#if !defined(_MSC_VER)
+#  pragma GCC diagnostic pop
 #endif
 
 #include "var_export_line.h"

--- a/src/lib/var_export_text.c
+++ b/src/lib/var_export_text.c
@@ -17,15 +17,13 @@
 #include "lib/php-header.h"
 #include "ext/standard/php_string.h"
 #include "Zend/zend_closures.h"
-#if PHP_VERSION_ID >= 80100
-# if !defined(_MSC_VER)
-#   pragma GCC diagnostic push
-#   pragma GCC diagnostic ignored "-Wdeclaration-after-statement"
-# endif
-# include "zend_enum.h"
-# if !defined(_MSC_VER)
-#   pragma GCC diagnostic pop
-# endif
+#if !defined(_MSC_VER)
+#  pragma GCC diagnostic push
+#  pragma GCC diagnostic ignored "-Wdeclaration-after-statement"
+#endif
+#include "zend_enum.h"
+#if !defined(_MSC_VER)
+#  pragma GCC diagnostic pop
 #endif
 
 

--- a/src/lib/var_export_xml.c
+++ b/src/lib/var_export_xml.c
@@ -497,11 +497,9 @@ void xdebug_var_xml_attach_static_vars(xdebug_xml_node *node, xdebug_var_export_
 
 	xdebug_zend_hash_apply_protection_begin(static_members);
 
-#if PHP_VERSION_ID >= 80100
 	if (ce->default_static_members_count && !CE_STATIC_MEMBERS(ce)) {
 		zend_class_init_statics(ce);
 	}
-#endif
 
 	ZEND_HASH_FOREACH_PTR(static_members, zpi) {
 		xdebug_var_xml_attach_property_with_contents(zpi, static_container, options, ce, STR_NAME_VAL(ce->name), &children);
@@ -630,13 +628,7 @@ void xdebug_var_export_xml_node(zval **struc, xdebug_str *name, xdebug_xml_node 
 			/* Adding static properties */
 			xdebug_zend_hash_apply_protection_begin(&ce->properties_info);
 
-#if PHP_VERSION_ID >= 80100
 			zend_class_init_statics(ce);
-#else
-			if (ce->type == ZEND_INTERNAL_CLASS || (ce->ce_flags & ZEND_ACC_IMMUTABLE)) {
-				zend_class_init_statics(ce);
-			}
-#endif
 
 			ZEND_HASH_FOREACH_PTR(&ce->properties_info, zpi_val) {
 				object_item_add_zend_prop_to_merged_hash(zpi_val, merged_hash, (int) XDEBUG_OBJECT_ITEM_TYPE_STATIC_PROPERTY, Z_OBJ_P(*struc), ce);
@@ -655,7 +647,6 @@ void xdebug_var_export_xml_node(zval **struc, xdebug_str *name, xdebug_xml_node 
 				ZEND_HASH_FOREACH_KEY_VAL_IND(myht, num, key, tmp_val) {
 					int flags = XDEBUG_OBJECT_ITEM_TYPE_PROPERTY;
 
-#if PHP_VERSION_ID >= 80100
 					if (ce->type != ZEND_INTERNAL_CLASS && !HASH_KEY_IS_NUMERIC(key)) {
 						const char         *cls_name, *tmp_prop_name;
 						size_t              tmp_prop_name_len;
@@ -680,7 +671,6 @@ void xdebug_var_export_xml_node(zval **struc, xdebug_str *name, xdebug_xml_node 
 #endif
 						}
 					}
-#endif
 					object_item_add_to_merged_hash(tmp_val, num, key, merged_hash, flags, Z_OBJ_P(*struc));
 				} ZEND_HASH_FOREACH_END();
 
@@ -689,67 +679,14 @@ void xdebug_var_export_xml_node(zval **struc, xdebug_str *name, xdebug_xml_node 
 
 			xdebug_xml_add_attribute(node, "type", "object");
 
-#if PHP_VERSION_ID >= 80100 // Enums
 			{
 				zend_class_entry *ce = Z_OBJCE_P(*struc);
 				if (ce->ce_flags & ZEND_ACC_ENUM) {
 					xdebug_xml_expand_attribute_value(node, "facet", "enum");
 				}
 			}
-#endif
 
 			if (instanceof_function(Z_OBJCE_P(*struc), zend_ce_closure)) {
-#if PHP_VERSION_ID < 80200
-				xdebug_xml_node *closure_cont, *closure_func;
-				const zend_function *closure_function = zend_get_closure_method_def(Z_OBJ_P(*struc));
-
-				closure_cont = xdebug_xml_node_init("property");
-				xdebug_xml_add_attribute(closure_cont, "facet", "virtual readonly");
-				xdebug_xml_add_attribute(closure_cont, "name", "{closure}");
-				xdebug_xml_add_attribute(closure_cont, "type", "array");
-				xdebug_xml_add_attribute(closure_cont, "children", "1");
-				xdebug_xml_add_attribute(closure_cont, "page", "0");
-				xdebug_xml_add_attribute(closure_cont, "pagesize", "2");
-
-				if (closure_function->common.scope) {
-					xdebug_xml_node *closure_scope = xdebug_xml_node_init("property");
-					xdebug_xml_add_attribute(closure_scope, "facet", "readonly");
-					xdebug_xml_add_attribute(closure_scope, "name", "scope");
-					xdebug_xml_add_attribute(closure_scope, "type", "string");
-
-					if (closure_function->common.fn_flags & ZEND_ACC_STATIC) {
-						xdebug_xml_add_text_ex(
-							closure_scope,
-							ZSTR_VAL(closure_function->common.scope->name),
-							ZSTR_LEN(closure_function->common.scope->name),
-							0, 0
-						);
-					} else {
-						xdebug_xml_add_text_ex(closure_scope, (char*) "$this", 6, 0, 0);
-					}
-
-					xdebug_xml_add_child(closure_cont, closure_scope);
-					xdebug_xml_add_attribute(closure_cont, "numchildren", "2");
-				} else {
-					xdebug_xml_add_attribute(closure_cont, "numchildren", "1");
-				}
-
-				closure_func = xdebug_xml_node_init("property");
-				xdebug_xml_add_attribute(closure_func, "facet", "readonly");
-				xdebug_xml_add_attribute(closure_func, "name", "function");
-				xdebug_xml_add_attribute(closure_func, "type", "string");
-				xdebug_xml_add_text_ex(
-					closure_func,
-					ZSTR_VAL(closure_function->common.function_name),
-					ZSTR_LEN(closure_function->common.function_name),
-					0, 0
-				);
-				xdebug_xml_add_child(closure_cont, closure_func);
-
-				xdebug_xml_add_child(node, closure_cont);
-				extra_children = 1;
-#endif
-
 				xdebug_xml_expand_attribute_value(node, "facet", "closure");
 			}
 


### PR DESCRIPTION
Removes all remaining code that targeted versions of PHP lower than 8.2, which is the lowest version that we support