### PR TITLE
Fix broken DBGP emulator

### DIFF
--- a/tests/debugger/dbgp/dbgp-emulator.php
+++ b/tests/debugger/dbgp/dbgp-emulator.php
@@ -40,10 +40,10 @@ class DbgpEmulator extends DebugClient
 	}
 
 	// Override doRead to capture conversation
-	function doRead($conn, ?string $transaction_id = null)
+	function doRead($conn, ?string $transaction_id = null, ?array $options = [])
 	{
 		ob_start();
-		$result = parent::doRead($conn, $transaction_id);
+		$result = parent::doRead($conn, $transaction_id, $options);
 		$output = ob_get_clean();
 
 		if (!empty($output)) {


### PR DESCRIPTION
When we synced our php-debugger with the latest changes in Xdebug we included a change in the `dbgpclient.php` file which breaks our DBGP emulator. This PR fixes the issue by updating the emulator