### PR TITLE
feat: recover Windows test runs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -92,7 +92,7 @@ jobs:
                     php-version: ${{ inputs.php-version || '8.5' }}
                     arch: x64
                     ts: ${{ matrix.ts }}
-                    args: --enable-debugger
+                    args: --enable-php-debugger
                     run-tests: false
 
             -   name: Get build info
@@ -107,11 +107,11 @@ jobs:
                 id: find-dll
                 shell: pwsh
                 run: |
-                    $dll = Get-ChildItem -Path ${{ runner.temp }} -Recurse -Filter 'php_debugger.dll' | Select-Object -First 1
+                    $dll = Get-ChildItem -Path ${{ runner.temp }} -Recurse -Filter 'php_php_debugger.dll' | Select-Object -First 1
                     if (-not $dll) {
-                        $dll = Get-ChildItem -Recurse -Filter 'php_debugger.dll' | Select-Object -First 1
+                        $dll = Get-ChildItem -Recurse -Filter 'php_php_debugger.dll' | Select-Object -First 1
                     }
-                    if (-not $dll) { Write-Error 'php_debugger.dll not found'; exit 1 }
+                    if (-not $dll) { Write-Error 'php_php_debugger.dll not found'; exit 1 }
                     Write-Host "Found DLL at: $($dll.FullName)"
                     echo "dll_path=$($dll.FullName)" >> $env:GITHUB_OUTPUT
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -90,7 +90,7 @@ jobs:
                     php-version: ${{ matrix.php-version }}
                     arch: x64
                     ts: ${{ matrix.ts }}
-                    args: --enable-debugger
+                    args: --enable-php-debugger
                     run-tests: false
 
             -   name: Package artifact
@@ -100,11 +100,11 @@ jobs:
                     $phpVer = "${{ matrix.php-version }}"
                     $tsTag = "${{ matrix.ts }}"
                     $assetName = "php-debugger-php${phpVer}-${tsTag}-windows-x64.dll"
-                    $dll = Get-ChildItem -Path $env:RUNNER_TEMP -Recurse -Filter 'php_debugger.dll' -ErrorAction SilentlyContinue | Select-Object -First 1
+                    $dll = Get-ChildItem -Path $env:RUNNER_TEMP -Recurse -Filter 'php_php_debugger.dll' -ErrorAction SilentlyContinue | Select-Object -First 1
                     if (-not $dll) {
-                        $dll = Get-ChildItem -Recurse -Filter 'php_debugger.dll' -ErrorAction SilentlyContinue | Select-Object -First 1
+                        $dll = Get-ChildItem -Recurse -Filter 'php_php_debugger.dll' -ErrorAction SilentlyContinue | Select-Object -First 1
                     }
-                    if (-not $dll) { Write-Error "php_debugger.dll not found"; exit 1 }
+                    if (-not $dll) { Write-Error "php_php_debugger.dll not found"; exit 1 }
                     Write-Host "Found DLL at: $($dll.FullName)"
                     Copy-Item $dll.FullName -Destination $assetName
                     echo "asset_name=${assetName}" >> $env:GITHUB_OUTPUT

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -7,6 +7,40 @@ on:
     pull_request:
 
 jobs:
+    get-windows-extension-matrix:
+        runs-on: ubuntu-latest
+        name: "Generate Windows Build Matrix"
+        outputs:
+            matrix: ${{ steps.extension-matrix.outputs.matrix }}
+        steps:
+            - name: Checkout
+              uses: actions/checkout@v6
+            - name: Get The Windows Extension Matrix
+              id: extension-matrix
+              uses: php/php-windows-builder/extension-matrix@v1
+              with:
+                  php-version-list: '8.2, 8.3, 8.4, 8.5'
+                  arch-list: 'x64'
+
+    windows:
+        needs: get-windows-extension-matrix
+        runs-on: ${{ matrix.os }}
+        name: "Windows PHP ${{ matrix.php-version }} ${{ matrix.ts == 'ts' && 'ZTS' || 'NTS' }}"
+        strategy:
+            fail-fast: false
+            matrix: ${{fromJson(needs.get-windows-extension-matrix.outputs.matrix)}}
+        steps:
+            - name: Checkout
+              uses: actions/checkout@v6
+            - name: Build & run tests
+              uses: php/php-windows-builder/extension@v1
+              with:
+                  php-version: ${{ matrix.php-version }}
+                  arch: x64
+                  ts: ${{ matrix.ts }}
+                  args: --enable-php-debugger
+                  test-runner: run-xdebug-tests.php
+
     linux:
         runs-on: ubuntu-latest
         name: "PHP ${{ matrix.php }} ${{ matrix.zts && 'ZTS' || 'NTS' }} ${{ matrix.opcache && '(opcache)' || '' }}"

--- a/config.w32
+++ b/config.w32
@@ -1,8 +1,8 @@
 // vim:ft=javascript
 
-ARG_ENABLE("debugger", "PHP Debugger support", "no");
+ARG_ENABLE("php-debugger", "PHP Debugger support", "no");
 
-if (PHP_DEBUGGER == 'yes') {
+if (PHP_PHP_DEBUGGER == 'yes') {
 	var XDEBUG_BASE_SOURCES="base.c ctrl_socket.c"
 	var XDEBUG_LIB_SOURCES="usefulstuff.c cmd_parser.c compat.c crc32.c hash.c headers.c lib.c llist.c log.c set.c str.c timing.c trim.c var.c var_export_xml.c xdebug_strndup.c xml.c compat_stubs.c"
 	var XDEBUG_LIB_MAPS_SOURCES="maps.c maps_private.c parser.c"
@@ -20,16 +20,16 @@ if (PHP_DEBUGGER == 'yes') {
 	}
 
 	if (typeof(ZEND_EXTENSION) == 'undefined') {
-		EXTENSION('debugger', files);
+		EXTENSION('php_debugger', files);
 	} else {
-		ZEND_EXTENSION('debugger', files);
+		ZEND_EXTENSION('php_debugger', files);
 	}
-	ADD_FLAG("CFLAGS_DEBUGGER", " /I " + configure_module_dirname + " ");
-	ADD_FLAG("CFLAGS_DEBUGGER", " /I " + configure_module_dirname + "/src ");
-	ADD_SOURCES(configure_module_dirname + "/src/base", XDEBUG_BASE_SOURCES, "debugger");
-	ADD_SOURCES(configure_module_dirname + "/src/lib", XDEBUG_LIB_SOURCES, "debugger");
-	ADD_SOURCES(configure_module_dirname + "/src/lib/maps", XDEBUG_LIB_MAPS_SOURCES, "debugger");
-	ADD_SOURCES(configure_module_dirname + "/src/debugger", XDEBUG_DEBUGGER_SOURCES, "debugger");
+	ADD_FLAG("CFLAGS_PHP_DEBUGGER", " /I " + configure_module_dirname + " ");
+	ADD_FLAG("CFLAGS_PHP_DEBUGGER", " /I " + configure_module_dirname + "/src ");
+	ADD_SOURCES(configure_module_dirname + "/src/base", XDEBUG_BASE_SOURCES, "php_debugger");
+	ADD_SOURCES(configure_module_dirname + "/src/lib", XDEBUG_LIB_SOURCES, "php_debugger");
+	ADD_SOURCES(configure_module_dirname + "/src/lib/maps", XDEBUG_LIB_MAPS_SOURCES, "php_debugger");
+	ADD_SOURCES(configure_module_dirname + "/src/debugger", XDEBUG_DEBUGGER_SOURCES, "php_debugger");
 
 	AC_DEFINE("HAVE_XDEBUG_CONTROL_SOCKET_SUPPORT", 1, "PHP Debugger control socket support");
 	AC_DEFINE("HAVE_XDEBUG", 1, "PHP Debugger support");

--- a/tests/debugger/remote_log-win.phpt
+++ b/tests/debugger/remote_log-win.phpt
@@ -32,3 +32,4 @@ echo file_get_contents("C:\\Windows\\Temp\\remote-log-win.txt");
 [%d] [Step Debug] WARN: Creating socket for 'doesnotexist3:9003', getaddrinfo: %d.
 [%d] [Step Debug] WARN: Could not connect to client host discovered through HTTP headers, connecting to configured address/port: doesnotexist2:9003.
 [%d] [Step Debug] WARN: Creating socket for 'doesnotexist2:9003', getaddrinfo: 11001.
+[%d] [Step Debug] DEBUG: Adding header 'Content-type: %s'.


### PR DESCRIPTION
Recovers testing on Windows which had been removed on a previous step.

Main problem was that we had defined the extension as having the name `debugger`, not `php-debugger`. This meant that some checks for the COMPILE_DL_PHP_DEBUGGER flag were not working as it was actually being set as COMPILE_DL_DEBUGGER. Updating config.m4 to use this correct name fixes the problem and all tests on Windows are now passing 👍 

Notice that now the DLL is named php_php_debugger.dll. This is correct as Windows DLLs are all named `php_name_of_the extension.dll` so the duplicate `php_` bit matches the standard