### PR TITLE
chore: Updates the versions of Upload actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -68,7 +68,7 @@ jobs:
                     echo "artifact_name=php-debugger-php${PHP_VER}-${OS_TAG}-${ARCH}" >> $GITHUB_OUTPUT
 
             -   name: Upload artifact
-                uses: actions/upload-artifact@v4
+                uses: actions/upload-artifact@v6
                 with:
                     name: ${{ steps.info.outputs.artifact_name }}
                     path: modules/php_debugger.so
@@ -116,7 +116,7 @@ jobs:
                     echo "dll_path=$($dll.FullName)" >> $env:GITHUB_OUTPUT
 
             -   name: Upload artifact
-                uses: actions/upload-artifact@v4
+                uses: actions/upload-artifact@v6
                 with:
                     name: ${{ steps.info.outputs.artifact_name }}
                     path: ${{ steps.find-dll.outputs.dll_path }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,7 +62,7 @@ jobs:
                     echo "asset_name=${ASSET_NAME}" >> $GITHUB_OUTPUT
 
             -   name: Upload artifact
-                uses: actions/upload-artifact@v4
+                uses: actions/upload-artifact@v6
                 with:
                     name: ${{ steps.package.outputs.asset_name }}
                     path: ${{ steps.package.outputs.asset_name }}
@@ -110,7 +110,7 @@ jobs:
                     echo "asset_name=${assetName}" >> $env:GITHUB_OUTPUT
 
             -   name: Upload artifact
-                uses: actions/upload-artifact@v4
+                uses: actions/upload-artifact@v6
                 with:
                     name: ${{ steps.package.outputs.asset_name }}
                     path: ${{ steps.package.outputs.asset_name }}

--- a/.github/workflows/sanitizers.yml
+++ b/.github/workflows/sanitizers.yml
@@ -96,7 +96,7 @@ jobs:
 
       - name: Upload test logs on failure
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: sanitizer-logs-${{ matrix.php }}
           path: |


### PR DESCRIPTION
`actions/upload-artifact@v4` is deprecated as it runs on Node 20. Update our project to use the new V6 version